### PR TITLE
Updating links to instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,12 +20,12 @@ You also agree to abide by our
     which is explained in the chapter [Contributing to a Project][pro-git-chapter]
     in Scott Chacon's book *Pro Git*.
 
-3.  For our lessons,
-    you should branch from and submit pull requests against the `gh-pages` branch.
+3.  When editing lessons, please only commit changes to the Markdown
+    files, *not* the generated HTML.  We will re-create the HTML after
+    your pull request is merged.  (Working this way ensures that each
+    change only needs to be reviewed once, in one place.)
 
-4.  When editing lesson pages, you need only commit changes to the Markdown source files.
-
-5.  If you're looking for things to work on,
+4.  If you're looking for things to work on,
     please see [the list of issues for this repository][issues]
     or for [the template][lesson-template-issues],
     or have a look at [our actual lessons][swc-lessons].

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ You also agree to abide by our
 2.  For a list of helpful commands run `make` in this directory.
 
 [conduct]: CONDUCT.md
-[issues]: https://github.com/swcarpentry/lesson-example/issues
+[issues]: https://github.com/swcarpentry/r-novice-gapminder/issues
 [lesson-template-issues]: https://github.com/swcarpentry/lesson-template/issues
 [license]: LICENSE.md
 [pro-git-chapter]: http://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-R for reproducible scientific analysis
-===
+R for Reproducible Scientific Analysis
+======================================
 
 Introduction to R for non-programmers using gapminder data.
 
@@ -42,29 +42,24 @@ the [lesson template documentation][dependencies], you also need to install the
 R package [knitr][].
 
 Once you've made your edits and looked over the rendered html files, you should
- add, commit, and push **only the source R Markdown file(s)** to your fork, and 
- then open a pull request. The repository  maintainers will run the html 
- generation process once the pull request has been merged. You can learn more 
- about the design of the build process [here][design].
-
-[issues]: https://github.com/swcarpentry/r-novice-gapminder/issues 
-[contrib]: https://github.com/swcarpentry/r-novice-gapminder/blob/gh-pages/CONTRIBUTING.md
-[dependencies]:
-https://github.com/swcarpentry/lesson-template#dependencies 
-[knitr]:
-http://cran.r-project.org/web/packages/knitr/index.html 
-[design]:
-https://github.com/swcarpentry/lesson-template/blob/gh-pages/DESIGN.md
+add, commit, and push **only the source R Markdown file(s)** to your fork, and 
+then open a pull request. The repository  maintainers will run the html 
+generation process once the pull request has been merged. You can learn more 
+about the design of the build process [here][design].
 
 ## Getting Help
 
-> Please see
-> [https://github.com/swcarpentry/lesson-template](https://github.com/swcarpentry/lesson-template)
-> for instructions on formatting, building, and submitting lessons, or run
-> `make` in this directory for a list of helpful commands.
+Please see
+[https://github.com/swcarpentry/lesson-example](https://github.com/swcarpentry/lesson-example)
+for instructions on formatting, building, and submitting lessons, or run
+`make` in this directory for a list of helpful commands.
 
 If you have questions or proposals, please send them to the [r-discuss][]
 mailing list.
 
-[r-discuss]:
-http://lists.software-carpentry.org/mailman/listinfo/r-discuss_lists.software-carpentry.org
+[contrib]: https://github.com/swcarpentry/r-novice-gapminder/blob/gh-pages/CONTRIBUTING.md
+[dependencies]: https://github.com/swcarpentry/lesson-template#dependencies 
+[design]: https://github.com/swcarpentry/lesson-template/blob/gh-pages/DESIGN.md
+[issues]: https://github.com/swcarpentry/r-novice-gapminder/issues 
+[knitr]: http://cran.r-project.org/web/packages/knitr/index.html 
+[r-discuss]: http://lists.software-carpentry.org/mailman/listinfo/r-discuss_lists.software-carpentry.org


### PR DESCRIPTION
Pointing at lesson-example instead of lesson-template, and telling people (again) not to commit HTML.