### PR TITLE
output of rbind is duplicated

### DIFF
--- a/05-data-structures-part2.md
+++ b/05-data-structures-part2.md
@@ -128,13 +128,6 @@ df <- rbind(df, list("g", 11, 42, 0, "G"))
 
 
 
-~~~{.output}
-Warning in `[<-.factor`(`*tmp*`, ri, value = "g"): invalid factor level, NA
-generated
-
-~~~
-
-
 
 ~~~{.output}
 Warning in `[<-.factor`(`*tmp*`, ri, value = "G"): invalid factor level, NA


### PR DESCRIPTION
this should be removed
~~~{.output}
Warning in `[<-.factor`(`*tmp*`, ri, value = "g"): invalid factor level, NA
generated

~~~