### PR TITLE
Fix format of first tip in RStudio section

### DIFF
--- a/01-rstudio-intro.Rmd
+++ b/01-rstudio-intro.Rmd
@@ -58,18 +58,18 @@ interactive R console.
    * You will be able to run the file you create from within RStudio
    or using R's `source()`  function.
 
-> ## Tip: Running segments of your code {.callout} RStudio offers
-> you great flexibility in running code from within the editor
-> window. There are buttons, menu choices, and keyboard shortcuts. To
-> run the current line, you can 1.  click on the `Run` button just
-> above the editor panel, or 2.  select "Run Lines" from the "Code"
-> menu, or 3.  hit Ctrl-Enter in Windows or Linux or Command-Enter on
-> OS X. (This shortcut can also be seen by hovering the mouse over the
-> button).  To run a block of code, select it and then `Run`. If you
-> have modified a line of code within a block of code you have just
-> run, there is no need to reselct the section and `Run`, you can use
-> the next button along, `Re-run the previous region`. This will run
-> the previous code block inculding the modifications you have made.
+> ## Tip: Running segments of your code {.callout}
+>
+> RStudio offers you great flexibility in running code from within the editor
+> window. There are buttons, menu choices, and keyboard shortcuts. To run the
+> current line, you can 1. click on the `Run` button just above the editor panel,
+> or 2. select "Run Lines" from the "Code" menu, or 3. hit Ctrl-Enter in Windows
+> or Linux or Command-Enter on OS X. (This shortcut can also be seen by hovering
+> the mouse over the button). To run a block of code, select it and then `Run`.
+> If you have modified a line of code within a block of code you have just run,
+> there is no need to reselct the section and `Run`, you can use the next button
+> along, `Re-run the previous region`. This will run the previous code block
+> inculding the modifications you have made.
 
 ## Introduction to R
 


### PR DESCRIPTION
The text for the first tip started on the same line as the title and `{.callout}`, causing the tip to not display properly.
<img width="874" alt="screen shot 2015-11-13 at 3 41 44 pm" src="https://cloud.githubusercontent.com/assets/4452678/11160322/3026cf96-8a1d-11e5-89ee-edfe29f00087.png">

vs.

<img width="974" alt="screen shot 2015-11-13 at 3 41 51 pm" src="https://cloud.githubusercontent.com/assets/4452678/11160324/360918e2-8a1d-11e5-8730-72981fa23019.png">
