### PR TITLE
Update names used in RStudio interface

### DIFF
--- a/01-rstudio-intro.Rmd
+++ b/01-rstudio-intro.Rmd
@@ -38,8 +38,8 @@ control and project management.
 When you first open RStudio, you will be greeted by three panels:
 
   * The interactive R console (entire left)
-  * Workspace/History (tabbed in upper right)
-  * Files/Plots/Packages/Help (tabbed in lower right)
+  * Environment/History (tabbed in upper right)
+  * Files/Plots/Packages/Help/Viewer (tabbed in lower right)
 
 Once you open files, such as R scripts, an editor panel will also open
 in the top left.


### PR DESCRIPTION
The Interface in RStudio does not have `Workspace` anymore but `Environment`. Also since some time there is `Viewer` tab in bottom right pane by default.