### PR TITLE
fix legend label error

### DIFF
--- a/08-plot-ggplot2.Rmd
+++ b/08-plot-ggplot2.Rmd
@@ -237,7 +237,7 @@ for changing the axis labels. To change the legend title, we need to use the
 ggplot(data = gapminder, aes(x = year, y = lifeExp, color=continent)) +
   geom_line() + facet_wrap( ~ country) +
   xlab("Year") + ylab("Life expectancy") + ggtitle("Figure 1") +
-  scale_fill_discrete(name="Continent") +
+  scale_colour_discrete(name="Continent") +
   theme(axis.text.x=element_blank(), axis.ticks.x=element_blank())
 ```
 


### PR DESCRIPTION
The example code under *Modifying Text* uses `scale_fill_discrete()` to change the label on the legend from "continent" to "Continent". However this doesn't work, because it is a color scale. The fix is to change to `scale_colour_discrete(name="Continent")`.