### PR TITLE
Remove square-bracket subsetting from data lessons

### DIFF
--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -9,10 +9,13 @@ minutes: 90
 source("tools/chunk-options.R")
 
 ## Save the data
-cats <- data.frame(coat = c("calico", "black", "tabby"),
+cats_orig <- data.frame(coat = c("calico", "black", "tabby"),
                    weight = c(2.1, 5.0, 3.2), 
                    likes_string = c(1, 0, 1))
-write.csv(cats, "data/feline-data.csv", row.names = FALSE, quote = FALSE)
+cats_bad <- data.frame(coat = c("calico", "black", "tabby", "tabby"),
+                   weight = c(2.1, 5.0, 3.2, '2.3 or 2.4'), 
+                   likes_string = c(1, 0, 1, 1))
+cats <- cats_orig
 ```
 
 > ## Learning Objectives {.objectives}
@@ -33,10 +36,14 @@ tabby,3.2,1
 
 We can load this into R via the following:
 
-```{r}
+```{r, eval=FALSE}
 cats <- read.csv(file = "data/feline-data.csv")
+```
+
+```{r}
 cats
 ```
+
 
 The `read.csv` function is used for reading in tabular data stored in a text file where the columns of data are delimited by commas (csv = comma separated values). Tabs are also commonly used to separated colums - if you data are in this format you can use the function `read.delim`. If the columns in your data are delimited by a character other than commas or tabs, you can use the more general `read.table` function.
 
@@ -96,19 +103,21 @@ Go back to your text editor and add this line to feline-data.csv:
 tabby,2.3 or 2.4,TRUE
 ```
 
-```{r, include=FALSE}
-cats <- data.frame(coat = c("calico", "black", "tabby", "tabby"),
-                   weight = c(2.1, 5.0, 3.2, '2.3 or 2.4'), 
-                   likes_string = c(1, 0, 1, 1))
-write.csv(cats, "data/feline-data.csv", row.names = FALSE, quote = FALSE)
-```
-
 Reload your cats data like before, and check what type of data we find in the `weight` column:
 
-```{r}
+
+```{r, include=FALSE}
+cats <- cats_bad
+```
+
+```{r, eval=FALSE}
 cats <- read.csv(file="data/feline-data.csv")
+```
+
+```{r}
 typeof(cats$weight)
 ```
+
 
 Oh no, our weights aren't the double type anymore! If we try to do the same math we did on them before, we run into trouble:
 
@@ -132,6 +141,11 @@ And back in RStudio:
 ```
 cats <- read.csv(file="data/feline-data.csv")
 ```
+
+```{r, include=FALSE}
+cats <- cats_orig
+```
+
 
 ## Vectors & Type Coercion
 

--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -297,6 +297,7 @@ We can turn a vector into a factor like so:
 
 ```{r}
 CATegories <- factor(coats)
+class(CATegories)
 str(CATegories)
 ```
 
@@ -369,7 +370,7 @@ matrix_example
 > ## Challenge 3 {.challenge}
 >
 > What do you think will be the result of
-> `length(x)`?
+> `length(matrix_example)`?
 > Try it.
 > Were you right? Why / why not?
 >
@@ -414,9 +415,9 @@ matrix_example
 > ## Solution to Challenge 1 {.challenge}
 >
 > ```{r}
-> x <- 11:20
-> subset <- x[3:5]
-> names(subset) <- c('S', 'W', 'C')
+> x <- 1:26
+> x <- x * 2
+> names(x) <- LETTERS
 > ```
 >
 
@@ -433,11 +434,11 @@ matrix_example
 > ## Solution to challenge 3 {.challenge}
 >
 > What do you think will be the result of
-> `length(x)`?
+> `length(matrtix_example)`?
 >
 > ```{r}
-> x <- matrix(0, ncol=6, nrow=3)
-> length(x)
+> matrix_example <- matrix(0, ncol=6, nrow=3)
+> length(matrix_example)
 > ```
 > 
 > Because a matrix is really just a vector with added dimension attributes, `length`

--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -81,7 +81,16 @@ typeof(TRUE)
 typeof('banana')
 ```
 
-Note the `L` suffix to insist that a number is an integer. No matter how complicated our analyses become, all data in R is interpreted as one of these basic data types. This strictness has some really important concequences. Go back to your text editor and add add this line to feline-data.csv:
+Note the `L` suffix to insist that a number is an integer. No matter how complicated our analyses become, all data in R is interpreted as one of these basic data types. This strictness has some really important concequences.
+
+The *type* of an R object refers to the basic data type. Objects also have a *class*, accessible with the `class` function, which can give you further information about an object. For example:
+
+```{r}
+class(cats)
+class(cats$likes_string)
+```
+
+Go back to your text editor and add this line to feline-data.csv:
 
 ```{r, eval=FALSE}
 tabby,2.3 or 2.4,TRUE

--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -68,12 +68,12 @@ Understanding what happened here is key to successfully analyzing data in R.
 If you guessed that the last command will return an error because 2.1 plus black is nonsense, you're right - and you already have some intuition for an important concept in programming called *data types*. We can ask what type of data something is:
 
 ```{r}
-typeof(cats$weight[1])
+typeof(cats$weight)
 ```
 
 There are 5 main types: doubles, integers, complex, logical and character.
 
-```
+```{r}
 typeof(3.14)
 typeof(1L)
 typeof(1+1i)
@@ -87,11 +87,18 @@ Note the `L` suffix to insist that a number is an integer. No matter how complic
 tabby,2.3 or 2.4,TRUE
 ```
 
+```{r, include=FALSE}
+cats <- data.frame(coat = c("calico", "black", "tabby", "tabby"),
+                   weight = c(2.1, 5.0, 3.2, '2.3 or 2.4'), 
+                   likes_string = c(1, 0, 1, 1))
+write.csv(cats, "data/feline-data.csv", row.names = FALSE, quote = FALSE)
+```
+
 Reload your cats data like before, and check what type of data we find in the `weight` column:
 
 ```{r}
 cats <- read.csv(file="data/feline-data.csv")
-typeof(cats$weight[1])
+typeof(cats$weight)
 ```
 
 Oh no, our weights aren't the double type anymore! If we try to do the same math we did on them before, we run into trouble:

--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -113,7 +113,7 @@ typeof(cats$weight)
 Oh no, our weights aren't the double type anymore! If we try to do the same math we did on them before, we run into trouble:
 
 ```{r}
-cats$weight[1] + cats$weight[2]
+cats$weight + 2
 ```
 
 What happened? When R reads a csv into one of these tables, it insists that everything in a column be the same basic type; if it can't understand *everything* in the column as a double, then *nobody* in the column gets to be a double. The table that R loaded our cats data into is something called a *data.frame*, and it is our first example of something called a *data structure* - things that R knows how to build out of the basic data types. In order to successfully use our data in R, we need to understand what these basic data structures are, and how they behave. For now, let's remove that extra line from our cats data and reload it, while we investigate this behavior further:
@@ -138,7 +138,7 @@ cats <- read.csv(file="data/feline-data.csv")
 To better understand the behavior we just saw, let's meet another of the data structures: the *vector*.
 
 ```{r}
-my_vector <- vector(length=3)
+my_vector <- vector(length = 3)
 my_vector
 ```
 

--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -253,13 +253,13 @@ tail(sequence_example, n=4)
 length(sequence_example)
 ```
 
-Finally, you can give names to elements in your vector, and ask for them that way:
+Finally, you can give names to elements in your vector:
 
 ```{r}
 names_example <- 5:8
 names(names_example) <- c("a", "b", "c", "d")
 names_example
-names_example['b']
+names(names_example)
 ```
 
 > ## Challenge 1 {.challenge}

--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -45,7 +45,7 @@ cats
 ```
 
 
-The `read.csv` function is used for reading in tabular data stored in a text file where the columns of data are delimited by commas (csv = comma separated values). Tabs are also commonly used to separated colums - if you data are in this format you can use the function `read.delim`. If the columns in your data are delimited by a character other than commas or tabs, you can use the more general `read.table` function.
+The `read.csv` function is used for reading in tabular data stored in a text file where the columns of data are delimited by commas (csv = comma separated values). Tabs are also commonly used to separated colums - if your data are in this format you can use the function `read.delim`. If the columns in your data are delimited by a character other than commas or tabs, you can use the more general and flexible `read.table` function.
 
 We can begin exploring our dataset right away, pulling out columns by specifying them using the `$` operator:
 

--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -225,7 +225,7 @@ numeric_coerced_to_logical
 
 As you can see, some surprising things can happen when R forces one basic data type into another! Nitty-gritty of type coercion aside, the point is: if your data doesn't look like what you thought it was going to look like, type coercion may well be to blame; make sure everything is the same type in your vectors and your columns of data.frames, or you will get nasty surprises!
 
-But coercion isn't a bad thing. For example, in our `cats` data `likes_string` is numeric, but we know that the 1s and 0s actually represent `TRUE` and `FALSE` (a common way of representing them). We should use the `logical` datatype here, which has two states: `TRUE` or `FALSE`, which is exactly what our data represents. We can 'coerce' this column to be `logical` by using the `as.logical` function:
+But coercion can also be very useful! For example, in our `cats` data `likes_string` is numeric, but we know that the 1s and 0s actually represent `TRUE` and `FALSE` (a common way of representing them). We should use the `logical` datatype here, which has two states: `TRUE` or `FALSE`, which is exactly what our data represents. We can 'coerce' this column to be `logical` by using the `as.logical` function:
 
 ```{r}
 cats$likes_string

--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -93,7 +93,6 @@ Note the `L` suffix to insist that a number is an integer. No matter how complic
 The *type* of an R object refers to the basic data type. Objects also have a *class*, accessible with the `class` function, which can give you further information about an object. For example:
 
 ```{r}
-class(cats)
 class(cats$likes_string)
 ```
 
@@ -125,7 +124,15 @@ Oh no, our weights aren't the double type anymore! If we try to do the same math
 cats$weight + 2
 ```
 
-What happened? When R reads a csv into one of these tables, it insists that everything in a column be the same basic type; if it can't understand *everything* in the column as a double, then *nobody* in the column gets to be a double. The table that R loaded our cats data into is something called a *data.frame*, and it is our first example of something called a *data structure* - things that R knows how to build out of the basic data types. In order to successfully use our data in R, we need to understand what these basic data structures are, and how they behave. For now, let's remove that extra line from our cats data and reload it, while we investigate this behavior further:
+What happened? When R reads a csv into one of these tables, it insists that everything in a column be the same basic type; if it can't understand *everything* in the column as a double, then *nobody* in the column gets to be a double. 
+
+The table that R loaded our cats data into is something called a *data.frame*, and it is our first example of something called a *data structure* - things that R knows how to build out of the basic data types. We can see that it is a *data.frame* by calling the `class` function on it:
+
+```{r}
+class(cats)
+```
+
+In order to successfully use our data in R, we need to understand what the basic data structures are, and how they behave. For now, let's remove that extra line from our cats data and reload it, while we investigate this behavior further:
 
 feline-data.csv:
 

--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -138,7 +138,7 @@ tabby,3.2,TRUE
 
 And back in RStudio:
 
-```
+```{r, eval=FALSE}
 cats <- read.csv(file="data/feline-data.csv")
 ```
 

--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -218,6 +218,14 @@ numeric_coerced_to_logical
 
 As you can see, some surprising things can happen when R forces one basic data type into another! Nitty-gritty of type coercion aside, the point is: if your data doesn't look like what you thought it was going to look like, type coercion may well be to blame; make sure everything is the same type in your vectors and your columns of data.frames, or you will get nasty surprises!
 
+But coercion isn't a bad thing. For example, in our `cats` data `likes_string` is numeric, but we know that the 1s and 0s actually represent `TRUE` and `FALSE` (a common way of representing them). We should use the `logical` datatype here, which has two states: `TRUE` or `FALSE`, which is exactly what our data represents. We can 'coerce' this column to be `logical` by using the `as.logical` function:
+
+```{r}
+cats$likes_string
+cats$likes_string <- as.logical(cats$likes_string)
+cats$likes_string
+```
+
 Concatenate will also append things to an existing vector:
 
 ```{r}

--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -7,6 +7,12 @@ minutes: 90
 
 ```{r, include=FALSE}
 source("tools/chunk-options.R")
+
+## Save the data
+cats <- data.frame(coat = c("calico", "black", "tabby"),
+                   weight = c(2.1, 5.0, 3.2), 
+                   likes_string = c(1, 0, 1))
+write.csv(cats, "data/feline-data.csv", row.names = FALSE, quote = FALSE)
 ```
 
 > ## Learning Objectives {.objectives}
@@ -28,7 +34,7 @@ tabby,3.2,TRUE
 We can load this into R via the following:
 
 ```{r}
-cats <- read.csv(file="data/feline-data.csv")
+cats <- read.csv(file = "data/feline-data.csv")
 cats
 ```
 

--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -26,9 +26,9 @@ One of R's most powerful features is its ability to deal with tabular data - lik
 
 ```{r, eval=FALSE}
 coat,weight,likes_string
-calico,2.1,TRUE   
-black,5.0,FALSE   
-tabby,3.2,TRUE 
+calico,2.1,1
+black,5.0,0
+tabby,3.2,1
 ```
 
 We can load this into R via the following:

--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -9,11 +9,11 @@ minutes: 90
 source("tools/chunk-options.R")
 
 ## Save the data
-cats_orig <- data.frame(coat = c("calico", "black", "tabby"),
+cats_orig <- data.frame(coat = factor(c("calico", "black", "tabby")),
                    weight = c(2.1, 5.0, 3.2), 
                    likes_string = c(1, 0, 1))
-cats_bad <- data.frame(coat = c("calico", "black", "tabby", "tabby"),
-                   weight = c(2.1, 5.0, 3.2, '2.3 or 2.4'), 
+cats_bad <- data.frame(coat = factor(c("calico", "black", "tabby", "tabby")),
+                   weight = factor(c(2.1, 5.0, 3.2, '2.3 or 2.4')), 
                    likes_string = c(1, 0, 1, 1))
 cats <- cats_orig
 ```

--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -244,13 +244,15 @@ seq(10)
 seq(1,10, by=0.1)
 ```
 
-In addition to asking for elements of a vector with the square bracket notation, we can ask a few other questions about vectors:
+We can ask a few questions about vectors:
 
 ```{r}
 sequence_example <- seq(10)
 head(sequence_example, n=2)
 tail(sequence_example, n=4)
 length(sequence_example)
+class(sequence_example)
+typeof(sequence_example)
 ```
 
 Finally, you can give names to elements in your vector:

--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -265,9 +265,9 @@ names(names_example)
 ```
 
 > ## Challenge 1 {.challenge}
-> Start by making a vector with the numbers 11 to 20. 
-> Then use the functions we just learned to extract the 3rd through 5th element in that vector into a new vector; 
-> name the elements in that new vector 'S', 'W', 'C'.
+> Start by making a vector with the numbers 1 through 26. 
+> Multiply the vector by 2, and give the resulting vector 
+> names A through Z (hint: there is a built in vector called `LETTERS`)
 >
 
 ## Factors

--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -203,7 +203,7 @@ Given what we've learned so far, what do you think the following will produce?
 quiz_vector <- c(2,6,'3')
 ```
 
-This is something called *type coercion*, and it is the source of many surprises and the reason why we need to be aware of the basic data types and how R will interpret them. Consider:
+This is something called *type coercion*, and it is the source of many surprises and the reason why we need to be aware of the basic data types and how R will interpret them. When R encounters a mix of types (here numeric and character) to be combined into a single vector, it will force them all to be the same type. Consider:
 
 ```{r}
 coercion_vector <- c('a', TRUE)

--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -38,19 +38,27 @@ cats <- read.csv(file = "data/feline-data.csv")
 cats
 ```
 
-We can begin exploring our dataset right away, pulling out columns and rows via the following:
+The `read.csv` function is used for reading in tabular data stored in a text file where the columns of data are delimited by commas (csv = comma separated values). Tabs are also commonly used to separated colums - if you data are in this format you can use the function `read.delim`. If the columns in your data are delimited by a character other than commas or tabs, you can use the more general `read.table` function.
+
+We can begin exploring our dataset right away, pulling out columns by specifying them using the `$` operator:
 
 ```{r}
 cats$weight
-cats$weight[1]
-cats$weight[2]
-cats$weight[1] + cats$weight[2]
+cats$coat
+```
+
+We can do other operations on the columns:
+
+```{r}
+## Say we discovered that the scale weighs one Kg light:
+cats$weight + 2
+paste("My cat is", cats$coat)
 ```
 
 But what about
 
 ```{r}
-cats$weight[1] + cats$coat[2]
+cats$weight + cats$coat
 ```
 
 Understanding what happened here is key to successfully analyzing data in R.

--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -362,15 +362,15 @@ matrix_example <- matrix(0, ncol=6, nrow=3)
 matrix_example
 ```
 
-and we can ask for and put values in the elements of our matrix with a couple of different notations:
+And similar to other data structures, we can ask things about our matrix:
 
 ```{r}
-matrix_example[1,1] <- 1
-matrix_example
-matrix_example[1][1]
-matrix_example[1][1] <- 2
-matrix_example[1,1]
-matrix_example
+class(matrix_example)
+typeof(matrix_example)
+str(matrix_example)
+dim(matrix_example)
+nrow(matrix_example)
+ncol(matrix_example)
 ```
 
 >

--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -403,15 +403,16 @@ matrix_example
 >
 
 > ## Solution to Challenge 1 {.challenge}
+>
 > ```{r}
-> x <- [11:20]
+> x <- 11:20
 > subset <- x[3:5]
 > names(subset) <- c('S', 'W', 'C')
 > ```
 >
 
 > ## Solution to Challenge 2 {.challenge}
-> ```{r}
+> ```{r, eval = FALSE}
 > cats <- read.csv(file="data/feline-data.csv", stringsAsFactors=FALSE)
 > str(cats$coat)
 > ``` 
@@ -426,7 +427,7 @@ matrix_example
 > `length(x)`?
 >
 > ```{r}
->x <- matrix(0, ncol=6, nrow=3)
+> x <- matrix(0, ncol=6, nrow=3)
 > length(x)
 > ```
 > 

--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -333,7 +333,6 @@ Another data structure you'll want in your bag of tricks is the `list`. A list i
 ```{r}
 list_example <- list(1, "a", TRUE, 1+4i)
 list_example
-list_example[2]
 another_list <- list(title = "Research Bazaar", numbers = 1:10, data = TRUE )
 another_list
 ```

--- a/04-data-structures-part1.Rmd
+++ b/04-data-structures-part1.Rmd
@@ -279,7 +279,7 @@ str(cats$weight)
 str(cats$likes_string)
 ```
 
-But what about
+These make sense. But what about
 
 ```{r}
 str(cats$coat)
@@ -303,8 +303,8 @@ str(CATegories)
 Now R has noticed that there are three possible categories in our data - but it also did something surprising; instead of printing out the strings we gave it, we got a bunch of numbers instead. R has replaced our human-readable categories with numbered indices under the hood:
 
 ```{r}
-typeof(coats[1])
-typeof(CATegories[1])
+typeof(coats)
+typeof(CATegories)
 ```
 
 > ## Challenge 2 {.challenge}

--- a/05-data-structures-part2.Rmd
+++ b/05-data-structures-part2.Rmd
@@ -67,20 +67,13 @@ cats$coat <- as.character(cats$coat)
 str(cats)
 ```
 
-We now know how to add rows and columns to our data.frame in R - but in our work we've accidentally added a garbage row. We can ask for a data.frame minus this offender:
-
-```{r}
-cats[-4,]
-```
-
-Notice the comma with nothing after it to indicate we want to drop the entire fourth row. 
-Alternatively, we can drop all rows with `NA` values:
+We now know how to add rows and columns to our data.frame in R - but in our work we've accidentally added a garbage row. We can drop all rows with `NA` values:
 
 ```{r}
 na.omit(cats)
 ```
 
-In either case, we need to reassign our variable to persist the changes:
+Let's reassign our variable to persist the changes:
 
 ```{r}
 cats <- na.omit(cats)

--- a/05-data-structures-part2.Rmd
+++ b/05-data-structures-part2.Rmd
@@ -25,29 +25,23 @@ At this point, you've see it all - in the last lesson, we toured all the basic d
 We learned last time that the columns in a data.frame were vectors, so that our data are consistent in type throughout the column. As such, if we want to add a new column, we need to start by making a new vector:
 
 ```{r}
-newCol <- c(2,3,5,12)
+age <- c(2,3,5,12)
 cats
 ```
 
 We can then add this as a column via:
 
-```{r}
-cats <- cbind(cats,  newCol)
+```{r, error=TRUE}
+cats <- cbind(cats, age)
 ```
 
 Why didn't this work? Of course, R wants to see one element in our new column for every row in the table:
 
 ```{r}
 cats
-newCol <- c(4,5,8)
-cats <- cbind(cats, newCol)
+age <- c(4,5,8)
+cats <- cbind(cats, age)
 cats
-```
-
-Our new column has appeared, but it's got that ugly name at the top; let's give it something a little easier to understand:
-
-```{r}
-names(cats)[4] <- 'age'
 ```
 
 Now how about adding rows - in this case, we saw last time that the rows of a data.frame are made of lists:

--- a/05-data-structures-part2.Rmd
+++ b/05-data-structures-part2.Rmd
@@ -7,6 +7,11 @@ minutes: 45
 
 ```{r, include=FALSE}
 source("tools/chunk-options.R")
+
+## Save the data
+cats <- data.frame(coat = factor(c("calico", "black", "tabby")),
+                   weight = c(2.1, 5.0, 3.2), 
+                   likes_string = c(1, 0, 1))
 ```
 
 > ## Learning Objectives {.objectives}

--- a/05-data-structures-part2.Rmd
+++ b/05-data-structures-part2.Rmd
@@ -79,14 +79,6 @@ Let's reassign our variable to persist the changes:
 cats <- na.omit(cats)
 ```
 
-> ## Discussion 1 {.challenge} 
-> What do you think
-> ```
-> cats$weight[4]
-> ```
-> will print at this point?
->
-
 The key to remember when adding data to a data.frame is that *columns are vectors or factors, and rows are lists.*
 We can also glue two dataframes together with `rbind`:
 
@@ -94,7 +86,7 @@ We can also glue two dataframes together with `rbind`:
 cats <- rbind(cats, cats)
 cats
 ```
-But now the row names are unnecessarily complicated. We can ask R to re-name everything sequentially:
+But now the row names are unnecessarily complicated. We can remove the rownames, and R will re-name them sequentially:
 
 ```{r}
 rownames(cats) <- NULL
@@ -211,12 +203,6 @@ into a script file so we can come back to it later.
 >
 
 ## Challenge solutions
-
-> ## Discussion 1 {.challenge}
-> Note the difference between row indices, and default row names;
-> even though there's no more row named '4',
-> cats[4,] is still well-defined (and pointing at the row named '5').
->
 
 > ## Solution to Challenge 1 {.challenge}
 > ```{r}

--- a/05-data-structures-part2.Rmd
+++ b/05-data-structures-part2.Rmd
@@ -208,7 +208,6 @@ into a script file so we can come back to it later.
 > ```{r}
 > df <- data.frame(first = c('Grace'), last = c('Hopper'), lucky_number = c(0), stringsAsFactors = FALSE)
 > df <- rbind(df, list('Marie', 'Curie', 238) )
-> df <- cbind(df, c(TRUE,TRUE))
-> names(df)[4] <- 'coffeetime'
+> df <- cbind(df, coffeetime = c(TRUE,TRUE))
 > ```
 >

--- a/05-data-structures-part2.Rmd
+++ b/05-data-structures-part2.Rmd
@@ -86,7 +86,7 @@ We can also glue two dataframes together with `rbind`:
 cats <- rbind(cats, cats)
 cats
 ```
-But now the row names are unnecessarily complicated. We can remove the rownames, and R will re-name them sequentially:
+But now the row names are unnecessarily complicated. We can remove the rownames, and R will automatically re-name them sequentially:
 
 ```{r}
 rownames(cats) <- NULL

--- a/05-data-structures-part2.Rmd
+++ b/05-data-structures-part2.Rmd
@@ -11,7 +11,7 @@ source("tools/chunk-options.R")
 ## Save the data
 cats <- data.frame(coat = factor(c("calico", "black", "tabby")),
                    weight = c(2.1, 5.0, 3.2), 
-                   likes_string = c(1, 0, 1))
+                   likes_string = c(TRUE, FALSE, TRUE))
 ```
 
 > ## Learning Objectives {.objectives}


### PR DESCRIPTION
As per the discussions in #89 , here is a pull request containing changes that remove square-bracket subsetting from the data lessons (04 and 05).

In addition, I:
- replaced `read.table` with `read.csv`, 
- added a bit of an introduction to classes (very basic), 
- made `cats$likes_string` with 1s and 0s instead of `TRUE` and `FALSE` to help illustrate coercion.

Things I didn't do:
- edit the introduction lesson to introduce function usage
- get rid of `rbind` and `cbind`
- rework subsetting lesson. I think it still works as is, but it might be worth having another look at it, and potentially incorporate moar cats.

I'm happy to work on those things, but I don't think it will happen in the very near future. If this PR looks okay, I think the overall R lesson will still work (though it would probably be worth a closer look) ... then I (or somebody else) can do those things if they are deemed necessary.