### PR TITLE
Fix footer 'Source' link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <div class="footer">
   <a class="label swc-blue-bg" href="http://software-carpentry.org">Software Carpentry</a>
-  <a class="label swc-blue-bg" href="https://github.com/swcarpentry/lesson-template">Source</a>
+  <a class="label swc-blue-bg" href="https://github.com/swcarpentry/r-novice-gapminder">Source</a>
   <a class="label swc-blue-bg" href="mailto:admin@software-carpentry.org">Contact</a>
   <a class="label swc-blue-bg" href="LICENSE.html">License</a>
 </div>


### PR DESCRIPTION
Change footer link 'Source' from the workshop template to the lesson repo at https://github.com/swcarpentry/r-novice-gapminder