### PR TITLE
Load the gap_wide dataset for tidyr lesson

### DIFF
--- a/14-tidyr.Rmd
+++ b/14-tidyr.Rmd
@@ -79,9 +79,13 @@ While using many of the functions in R, which are often vector based, you usuall
 ## From wide to long format with gather()
 Until now, we've been using the nicely formatted original gapminder dataset, but 'real' data (i.e. our own research data) will never be so well organized. Here let's start with the wide format version of the gapminder dataset.
 
+
+We'll load the data file and look at it.  Note: we don't want our continent and country columns to be factors, so we use the stringsAsFactors argument for `read.csv()` to disable that.  
 ```{r}
+gap_wide <- read.csv("data/gapminder_wide.csv", stringsAsFactors = FALSE)
 str(gap_wide)
 ```
+
 
 ![](fig/14-tidyr-fig2.png)
 


### PR DESCRIPTION
Added R code to load the gap_wide dataset in Data Manipulation with tidyr.
This dataset is referenced in the lesson without being loaded.
Loading the data with read.csv() causes problems later (see #94) because
columns are loaded as Factor not chr.

Loading the dataset with stringsAsFactors = FALSE (referenced in comments on line 26 of the Rmd)
fixes the problem and the all.equal() function works as intended.
Columns 37 and 38 are still imported as int instead of num, but this does not lead to problems.