### PR TITLE
Add line for appropriate Tip formatting

### DIFF
--- a/07-control-flow.Rmd
+++ b/07-control-flow.Rmd
@@ -119,7 +119,8 @@ If your condition evaluates to a vector with more than one logical element,
 the function `if()` will still run, but will only evaluate the condition in the first
 element. Here you need to make sure your condition is of length 1.
 
-> ## Tip: `any()` and `all()` {.callout}
+> ## Tip: any() and all() {.callout}
+>
 > The `any()` function will return TRUE if at least one
 > TRUE value is found within a vector, otherwise it will return `FALSE`.
 > This can be used in a similar way to the `%in%` operator.


### PR DESCRIPTION
The second Tip in the lesson (any and all) was not being formatted correctly.  I added an empty line between the tip header and content in an effort to get the formatting to work (thumb-tack image, blue box, etc.).