### PR TITLE
R novice gapminder exercise amendment

### DIFF
--- a/_episodes/06-data-subsetting.md
+++ b/_episodes/06-data-subsetting.md
@@ -1489,8 +1489,8 @@ be changed with the third argument, `drop = FALSE`).
 > ~~~
 > {: .r}
 >
-> 5. Advanced: extract rows that contain information for the years 2002
->    and 2007
+> 5. Advanced: extract rows that contain information for the continents Americas
+>    and Asia
 >
 > 
 > ~~~
@@ -1539,14 +1539,14 @@ be changed with the third argument, `drop = FALSE`).
 > > ~~~
 > > {: .r}
 > >
-> > 5. Advanced: extract rows that contain information for the years 2002
-> >    and 2007
+> > 5. Advanced: extract rows that contain information for the continents Americas 
+> >    and Asia
 > >
 > > 
 > > ~~~
-> > # gapminder[gapminder$year == 2002 | 2007,]
-> > gapminder[gapminder$year == 2002 | gapminder$year == 2007,]
-> > gapminder[gapminder$year %in% c(2002, 2007),]
+> > # gapminder[gapminder$continent == "Americas" | "Asia",]
+> > gapminder[gapminder$continent == "Americas" | gapminder$continent == "Asia",]
+> > gapminder[gapminder$continent %in% c("Americas", "Asia"),]
 > > ~~~
 > > {: .r}
 > {: .solution}

--- a/_episodes/06-data-subsetting.md
+++ b/_episodes/06-data-subsetting.md
@@ -1494,7 +1494,7 @@ be changed with the third argument, `drop = FALSE`).
 >
 > 
 > ~~~
-> gapminder[gapminder$year == 2002 | 2007,]
+> gapminder[gapminder$continent == "Americas" | "Asia",]
 > ~~~
 > {: .r}
 >

--- a/_episodes_rmd/06-data-subsetting.Rmd
+++ b/_episodes_rmd/06-data-subsetting.Rmd
@@ -803,11 +803,11 @@ be changed with the third argument, `drop = FALSE`).
 > gapminder[1, 4, 5]
 > ```
 >
-> 5. Advanced: extract rows that contain information for the years 2002
->    and 2007
+> 5. Advanced: extract rows that contain information for the continents Americas
+>    and Asia
 >
 > ```{r, eval=FALSE}
-> gapminder[gapminder$year == 2002 | 2007,]
+> gapminder[gapminder$continent == "Americas" | "Asia",]
 > ```
 >
 > > ## Solution to challenge 7
@@ -843,13 +843,12 @@ be changed with the third argument, `drop = FALSE`).
 > > gapminder[1, c(4, 5)]
 > > ```
 > >
-> > 5. Advanced: extract rows that contain information for the years 2002
-> >    and 2007
+> > 5. Advanced: extract rows that contain information for the continents > > Americas and Asia
 > >
 > > ```{r, eval=FALSE}
-> > # gapminder[gapminder$year == 2002 | 2007,]
-> > gapminder[gapminder$year == 2002 | gapminder$year == 2007,]
-> > gapminder[gapminder$year %in% c(2002, 2007),]
+> > # gapminder[gapminder$continent == "Americas" | "Asia",]
+> > gapminder[gapminder$continent == "Americas" | gapminder$continent == "Asia",]
+> > gapminder[gapminder$continent %in% c("Americas", "Asia"),]
 > > ```
 > {: .solution}
 {: .challenge}


### PR DESCRIPTION
The first exercise in challenge-7 of 06-data-subsetting demonstrates a subsetting error, which assigns all the values of gapminder$year to 1957. When students do not get this exercise right, they will also get the final exercise in the same challenge-7 wrong (because there will be no values for gapminder$year == 2002 | gapminder$year == 2007). It would be nice to learn this combinatorial subsetting independent of the previous example. So I suggested an amendment.
