### PR TITLE
Adding auto-generated IDs

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -250,6 +250,7 @@ behaviour of R).
 
 ## Glossary
 
+{:auto_ids}
 argument
 :   A value given to a function or program when it runs.
     The term is often used interchangeably (and inconsistently) with [parameter](#parameter).


### PR DESCRIPTION
The new version of Kramdown will add IDs to glossary entries (definition lists) if instructed to do so.