### PR TITLE
Changed DiagrammeR label font

### DIFF
--- a/fig/13-dplyr-generate-figures.R
+++ b/fig/13-dplyr-generate-figures.R
@@ -63,8 +63,8 @@ grViz('digraph html {
       rank = same; table1; table2;
       }
       
-      
       labelloc="t";
+      fontname="Courier";
       label="select(data.frame,a,c)";
       }
       ')
@@ -209,6 +209,7 @@ grViz('digraph html {
       }
       
       labelloc="t";
+      fontname="Courier";
       label="gapminder %>% group_by(a)";
       }
       ')
@@ -381,6 +382,7 @@ grViz('digraph html {
       }
       
       labelloc="t";
-      label="gapminder %>% group_by(a) %>% summarize(mean_b=mean(b))";
+      fontname="Courier";
+      label="gapminder %>%\\l\tgroup_by(a) %>%\\l\tsummarize(mean_b=mean(b))\\l";
       }
       ')

--- a/fig/14-tidyr-generate-figures.R
+++ b/fig/14-tidyr-generate-figures.R
@@ -103,6 +103,7 @@ grViz('digraph html {
       
       
       labelloc="t";
+      fontname="Courier";
       label="wide      vs      long";
       }
       ')
@@ -169,6 +170,7 @@ grViz('digraph html {
       </TABLE>>];
       
       labelloc="t";
+      fontname="Courier";
       label="wide format";
       }
       ')
@@ -377,6 +379,7 @@ grViz('digraph html {
       </TABLE>>];
       
       labelloc="t";
+      fontname="Courier";
       label="long format";
       }
       ')


### PR DESCRIPTION
Changed DiagrammeR font from Times New to Courier for all three figures in episode 13 - dplyr. Also split label for fig 3 across three rows to make it more 'dplyr-like'. Fixes issue #208