### PR TITLE
Episode 3, challenge 1: trailing backtick breaks example 

### DIFF
--- a/_episodes_rmd/03-seeking-help.Rmd
+++ b/_episodes_rmd/03-seeking-help.Rmd
@@ -115,7 +115,7 @@ your issue.
 > ```{r, eval=FALSE}
 > c(1, 2, 3)
 > c('d', 'e', 'f')
-> c(1, 2, 'f')`
+> c(1, 2, 'f')
 > ```
 > > ## Solution to Challenge 1
 > >


### PR DESCRIPTION
There is a trailing backtick in the third example vector of challenge 1 in episode 3. On verbatim execution in R this prohibits the correct execution of the c() function, instead leading to an R prompt expecting further input.