### PR TITLE
Modified illustration example to fit previous example better.

### DIFF
--- a/_episodes_rmd/06-data-subsetting.Rmd
+++ b/_episodes_rmd/06-data-subsetting.Rmd
@@ -327,22 +327,24 @@ to the corresponding element of its right argument.
 Here's a mock illustration:
 
 ```{r, eval=FALSE}
-c("a", "b", "c", "e")  # names of x
-   |    |    |    |    # The elements == is comparing
+c("a", "a", "a")  # names of x
+   |    |    |    # The elements == is comparing
 c("a", "c")
 ```
 
 When one vector is shorter than the other, it gets *recycled*:
 
 ```{r, eval=FALSE}
-c("a", "b", "c", "e")  # names of x
-   |    |    |    |    # The elements == is comparing
-c("a", "c", "a", "c")
+c("a", "a", "a")  # names of x
+   |    |    |    # The elements == is comparing
+c("a", "c", "a")
 ```
 
-In this case R simply repeats `c("a", "c")` twice. If the longer
-vector length isn't a multiple of the shorter vector length, then
-R will also print out a warning message:
+In this case R simply repeats `c("a", "c")` twice. Since the recycled "a"
+matches x again we got the output: TRUE FALSE TRUE
+
+If the longer vector length isn't a multiple of the shorter vector 
+length, then R will also print out a warning message.
 
 ```{r}
 names(x) == c('a', 'c', 'e')


### PR DESCRIPTION
When I was going over lesson 06 for subsetting data, I got a little confused by why the example illustration jumped back to the initial x vector assignment c("a", "b", "c", "d", "e"). I thought it would be better for continuity if the example illustration used the x vector previously assigned c("a", "a", "a") and went over what happens with you %in% with c("a", "c"). 