### PR TITLE
Fix weird title rendering

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -3,6 +3,8 @@ layout: reference
 permalink: /reference/
 ---
 
+## Reference
+
 ## [Introduction to R and RStudio]({{ page.root }}/01-rstudio-intro/)
 
  - Use the escape key to cancel incomplete commands or running code


### PR DESCRIPTION
This is the current page:
http://swcarpentry.github.io/r-novice-gapminder/reference/

Hopefully, it won't do that anymore.