### PR TITLE
Proof and copy edit for 04-data-structures-part1.Rmd

### DIFF
--- a/_episodes_rmd/04-data-structures-part1.Rmd
+++ b/_episodes_rmd/04-data-structures-part1.Rmd
@@ -62,15 +62,15 @@ cats <- read.csv(file = "data/feline-data.csv")
 cats
 ```
 
-
 The `read.table` function is used for reading in tabular data stored in a text
-file where the columns of data are delimited by punctuation characters such as
+file where the columns of data are separated by punctuation characters such as
 CSV files (csv = comma-separated values). Tabs and commas are the most common
-punctuation characters used to delimit data points in csv files. For
-convenience R provides 2 other versions of `read.table`. These are `read.csv`
-for files where the data is separated with commas and `read.delim` for files
-where the data is separated with tabs. If needed it is possible to override the
-default punctuation marks for both `read.csv` and `read.delim`.
+punctuation characters used to separate or delimit data points in csv files. 
+For convenience R provides 2 other versions of `read.table`. These are: `read.csv`
+for files where the data are separated with commas and `read.delim` for files
+where the data are separated with tabs. Of these three functions `read.csv` is
+the most commonly used.  If needed it is possible to override the default 
+delimiting punctuation marks for both `read.csv` and `read.delim`.
 
 
 We can begin exploring our dataset right away, pulling out columns by specifying
@@ -228,7 +228,7 @@ empty character strings. If we similarly do
 str(cats$weight)
 ```
 
-we see that is a vector, too - *the columns of data we load into R
+we see that `cats$weight` is a vector, too - *the columns of data we load into R
 data.frames are all vectors*, and that's the root of why R forces everything in
 a column to be the same basic data type.
 
@@ -242,10 +242,9 @@ a column to be the same basic data type.
 > > By keeping everything in a column the same, we allow ourselves to make simple
 > > assumptions about our data; if you can interpret one entry in the column as a
 > > number, then you can interpret *all* of them as numbers, so we don't have to
-> > check every time. This consistency, such as consistently using the same separator
-> > in our data files, is what people mean when they talk about *clean data*; in
-> > the long run, strict consistency goes a long way to making our lives easier in
-> > R.
+> > check every time. This consistency is what people mean when they talk about 
+> > *clean data*; in the long run, strict consistency goes a long way to making 
+> > our lives easier in R.
 > {: .solution}
 {: .discussion}
 

--- a/_episodes_rmd/04-data-structures-part1.Rmd
+++ b/_episodes_rmd/04-data-structures-part1.Rmd
@@ -32,7 +32,7 @@ cats <- cats_orig
 ```
 
 One of R's most powerful features is its ability to deal with tabular data -
-like what you might already have in a spreadsheet or a CSV. Let's start by
+such as you may already have in a spreadsheet or a CSV file. Let's start by
 making a toy dataset in your `data/` directory, called `feline-data.csv`:
 
 ```{r, eval=FALSE}
@@ -63,12 +63,14 @@ cats
 ```
 
 
-The `read.csv` function is used for reading in tabular data stored in a text
-file where the columns of data are delimited by commas (csv = comma-separated
-values). Tabs are also commonly used to separated columns - if your data are in
-this format you can use the function `read.delim`. If the columns in your data
-are delimited by a character other than commas or tabs, you can use the more
-general and flexible `read.table` function.
+The `read.table` function is used for reading in tabular data stored in a text
+file where the columns of data are delimited by punctuation characters such as
+CSV files (csv = comma-separated values). Tabs and commas are the most common
+punctuation characters used to delimit data points in csv files. For
+convenience R provides 2 other versions of `read.table`. These are `read.csv`
+for files where the data is separated with commas and `read.delim` for files
+where the data is separated with tabs. If needed it is possible to override the
+default punctuation marks for both `read.csv` and `read.delim`.
 
 
 We can begin exploring our dataset right away, pulling out columns by specifying
@@ -144,7 +146,6 @@ cats <- read.csv(file="data/feline-data_v2.csv")
 typeof(cats$weight)
 ```
 
-
 Oh no, our weights aren't the double type anymore! If we try to do the same math
 we did on them before, we run into trouble:
 
@@ -152,7 +153,7 @@ we did on them before, we run into trouble:
 cats$weight + 2
 ```
 
-What happened? When R reads a csv into one of these tables, it insists that
+What happened? When R reads a csv file into one of these tables, it insists that
 everything in a column be the same basic type; if it can't understand
 *everything* in the column as a double, then *nobody* in the column gets to be a
 double. The table that R loaded our cats data into is something called a
@@ -227,7 +228,7 @@ empty character strings. If we similarly do
 str(cats$weight)
 ```
 
-we see that that's a vector, too - *the columns of data we load into R
+we see that is a vector, too - *the columns of data we load into R
 data.frames are all vectors*, and that's the root of why R forces everything in
 a column to be the same basic data type.
 
@@ -241,7 +242,7 @@ a column to be the same basic data type.
 > > By keeping everything in a column the same, we allow ourselves to make simple
 > > assumptions about our data; if you can interpret one entry in the column as a
 > > number, then you can interpret *all* of them as numbers, so we don't have to
-> > check every time. This consistency, like consistently using the same separator
+> > check every time. This consistency, such as consistently using the same separator
 > > in our data files, is what people mean when they talk about *clean data*; in
 > > the long run, strict consistency goes a long way to making our lives easier in
 > > R.
@@ -306,7 +307,7 @@ cats$likes_string <- as.logical(cats$likes_string)
 cats$likes_string
 ```
 
-Combine `c()` will also append things to an existing vector:
+The combine function, `c()`, will also append things to an existing vector:
 
 ```{r}
 ab_vector <- c('a', 'b')
@@ -400,7 +401,8 @@ str(CATegories)
 Now R has noticed that there are three possible categories in our data - but it
 also did something surprising; instead of printing out the strings we gave it,
 we got a bunch of numbers instead. R has replaced our human-readable categories
-with numbered indices under the hood:
+with numbered indices under the hood, this is necessary as many statistical
+calculations utilise such numerical representations for categorical data:
 
 ```{r}
 typeof(coats)


### PR DESCRIPTION
For my instructor checkout I've given this lesson a basic proof and copy edit. It includes a handful of grammatical or styles changes to make it read more smoothly and correct one or two typos. The section on read.table/read.delim/read.csv has been rewritten.

Change notes by line:

35: "like what you might already have" not very natural english, not typically regarded as valid for (formal) written text
66: Updated the read.table/read.csv/read.delim description to correctly reflect who and why R provides these functions
156: "When R reads a csv file" - corrected the article
231: removed double 'that' for clearer reading
245: grammatical change to "such as" to clarify example is being given
310: moved c() to it's own clause and made explicit that we are talking about a function.
404: Clarified why R represents factors as indices