### PR TITLE
Suggested edits to code and explanation for setting labels in ggplot

### DIFF
--- a/_episodes_rmd/08-plot-ggplot2.Rmd
+++ b/_episodes_rmd/08-plot-ggplot2.Rmd
@@ -331,14 +331,13 @@ elements. The x-axis is too cluttered, and the y axis should read
 "Life expectancy", rather than the column name in the data frame.
 
 We can do this by adding a couple of different layers. The **theme** layer
-controls the axis text, and overall text size, and there are special layers
-for changing the axis labels. To change the legend title, we need to use the
-**scales** layer.
+controls the axis text, and overall text size. Labels for the axes, plot title and legend can be set using the `labs` function.
 
 ```{r theme}
 ggplot(data = az.countries, aes(x = year, y = lifeExp, color=continent)) +
   geom_line() + facet_wrap( ~ country) +
-  xlab("Year") + ylab("Life expectancy") + ggtitle("Figure 1") +
+  labs(x = "Year", y = "Life expectancy", 
+       title = "Figure 1", colour = "Continent") +
   scale_colour_discrete(name="Continent") +
   theme(axis.text.x=element_blank(), axis.ticks.x=element_blank())
 ```

--- a/_episodes_rmd/08-plot-ggplot2.Rmd
+++ b/_episodes_rmd/08-plot-ggplot2.Rmd
@@ -331,14 +331,13 @@ elements. The x-axis is too cluttered, and the y axis should read
 "Life expectancy", rather than the column name in the data frame.
 
 We can do this by adding a couple of different layers. The **theme** layer
-controls the axis text, and overall text size. Labels for the axes, plot title and legend can be set using the `labs` function.
+controls the axis text, and overall text size. Labels for the axes, plot title and legend can be set using the `labs` function. 
 
 ```{r theme}
 ggplot(data = az.countries, aes(x = year, y = lifeExp, color=continent)) +
   geom_line() + facet_wrap( ~ country) +
   labs(x = "Year", y = "Life expectancy", 
        title = "Figure 1", colour = "Continent") +
-  scale_colour_discrete(name="Continent") +
   theme(axis.text.x=element_blank(), axis.ticks.x=element_blank())
 ```
 


### PR DESCRIPTION
Under the section ## Modifying text heading. Using the `labs` argument might be simpler to explain `xlab`, `ylab`, `ggtitle`, and putting the header in an otherwise unnecessary `scale_colour` as in the example?

Sorry for the double commit, hadn't deleted the scale_colour_discrete in the first one. 