### PR TITLE
Fix link to R for Data Science in dplyr lesson

### DIFF
--- a/_episodes_rmd/13-dplyr.Rmd
+++ b/_episodes_rmd/13-dplyr.Rmd
@@ -307,7 +307,7 @@ gapminder %>%
 
 ## Other great resources
 
-* [R for Data Science](r4ds.had.co.nz)
+* [R for Data Science](http://r4ds.had.co.nz/)
 * [Data Wrangling Cheat sheet](https://www.rstudio.com/wp-content/uploads/2015/02/data-wrangling-cheatsheet.pdf)
 * [Introduction to dplyr](https://cran.rstudio.com/web/packages/dplyr/vignettes/introduction.html)
 * [Data wrangling with R and RStudio](https://www.rstudio.com/resources/webinars/data-wrangling-with-r-and-rstudio/)


### PR DESCRIPTION
Link to http://r4ds.had.co.nz/ in the dplyr lesson (episode 13) was incomplete.