### PR TITLE
s/scatter/spread as keypoint

### DIFF
--- a/_episodes_rmd/14-tidyr.Rmd
+++ b/_episodes_rmd/14-tidyr.Rmd
@@ -9,7 +9,7 @@ objectives:
 keypoints:
 - "Use the `tidyr` package to change the layout of dataframes."
 - "Use `gather()` to go from wide to long format."
-- "Use `scatter()` to go from long to wide format."
+- "Use `spread()` to go from long to wide format."
 source: Rmd
 ---
 


### PR DESCRIPTION
The keypoint says "scatter() to convert from long to wide" but there is no scatter command. It should be spread
