### PR TITLE
define variable 'y'

### DIFF
--- a/_episodes_rmd/01-rstudio-intro.Rmd
+++ b/_episodes_rmd/01-rstudio-intro.Rmd
@@ -343,6 +343,7 @@ Assignment values can contain the variable being assigned to:
 
 ```{r}
 x <- x + 1 #notice how RStudio updates its description of x on the top right tab
+y <- x * 2
 ```
 
 The right hand side of the assignment can be any valid R expression.


### PR DESCRIPTION
The output of the command ls() on line 397 shows two variables, x and y. But (confusingly) there is no place that the y variable is defined in the current lesson. This simple change will make the output of ls() consistent for anyone who is following along exactly.