### PR TITLE
Git Removal and Add Link

### DIFF
--- a/_episodes_rmd/02-project-intro.Rmd
+++ b/_episodes_rmd/02-project-intro.Rmd
@@ -5,14 +5,12 @@ exercises: 10
 questions:
 - "How can I manage my projects in R?"
 objectives:
-- To be able to create self-contained projects in RStudio
-- To be able to use git from within RStudio
+- Create self-contained projects in RStudio
 keypoints:
 - "Use RStudio to create and manage projects with consistent layout."
 - "Treat raw data as read-only."
 - "Treat generated output as disposable."
 - "Separate function definition and application."
-- "Use version control."
 source: Rmd
 ---
 
@@ -69,7 +67,7 @@ project.
 > 2. Click "New Directory".
 > 3. Click "Empty Project".
 > 4. Type in the name of the directory to store your project, e.g. "my_project".
-> 5. Make sure that the checkbox for "Create a git repository" is selected.
+> 5. If available, select the checkbox for "Create a git repository."
 > 6. Click the "Create Project" button.
 {: .challenge}
 
@@ -215,39 +213,6 @@ Now we have a good directory structure we will now place/save the data file in t
 
 ### Version Control
 
-We also set up our project to integrate with git, putting it under version control.
-RStudio has a nicer interface to git than shell, but is very limited in what it can
-do, so you will find yourself occasionally needing to use the shell. Let's go
-through and make an initial commit of our template files.
+It is important to use version control with projects.  Go [here](http://swcarpentry.github.io/git-novice/14-supplemental-rstudio/) for a good lesson which describes using Git with R Studio.
 
-The workspace/history pane has a tab for "Git". We can stage each file by checking the box:
-you will see a green "A" next to stage files and folders, and yellow question marks next to
-files or folders git doesn't know about yet. RStudio also nicely shows you the difference
-between files from different commits.
 
-> ## Tip: versioning disposable output
->
-> Generally you do not want to version disposable output (or read-only data).
-> You should modify the `.gitignore` file to tell git to ignore these files
-> and directories.
-{: .callout}
-
-> ## Challenge 3
->
-> 1. Create a directory within your project called `graphs`.
-> 2. Modify the `.gitignore` file to contain `graphs/`
-> so that this disposable output isn't versioned.
->
-> Add the newly created folders to version control using
-> the git interface.
->
-> > ## Solution to Challenge 3
-> >
-> > This can be done with the command line:
-> > ```
-> > $ mkdir graphs
-> > $ echo "graphs/" >> .gitignore
-> > ```
-> > {: . shell}
-> {: .solution}
-{: .challenge}


### PR DESCRIPTION
Information on installing and configuring Git with R Studio is missing.  Since Git is a cursory part of this lesson, this proposed file change will remove Git references and replace with link to better version of content in SWC Git lesson.
https://github.com/swcarpentry/r-novice-gapminder/issues/275
