### PR TITLE
redefine x so skipping-named-elements works

### DIFF
--- a/_episodes_rmd/06-data-subsetting.Rmd
+++ b/_episodes_rmd/06-data-subsetting.Rmd
@@ -197,6 +197,7 @@ x
 We can extract elements by using their name, instead of index:
 
 ```{r}
+x <- c(a=5.4, b=6.2, c=7.1, d=4.8, e=7.5) # we can name a vector 'on the fly'
 x[c("a", "c")]
 ```
 


### PR DESCRIPTION
intervening changes in `x` messed up the example. Redefining it is safer.