### PR TITLE
Fix interactive display for challenge 3

### DIFF
--- a/_episodes_rmd/03-seeking-help.Rmd
+++ b/_episodes_rmd/03-seeking-help.Rmd
@@ -175,7 +175,7 @@ your issue.
 > > separator for `read.table()`, although you may have to change
 > > the `comment.char` argument as well if your data file contains
 > > hash (#) characters
-> {: solution}
+> {: .solution}
 {: .challenge}
 
 ## Other ports of call


### PR DESCRIPTION
The closing `{: .solution}` for challenge 3 is missing a `.`. This breaks the interactive display of the solution. I'm adding the missing `.`.