### PR TITLE
Updated links for both issues and main repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,8 +144,8 @@ You can also [reach us by email][contact].
 [github-flow]: https://guides.github.com/introduction/flow/
 [github-join]: https://github.com/join
 [how-contribute]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
-[issues]: https://github.com/swcarpentry/FIXME/issues/
-[repo]: https://github.com/swcarpentry/FIXME/
+[issues]: https://github.com/swcarpentry/r-novice-gapminder/issues
+[repo]: https://github.com/swcarpentry/r-novice-gapminder
 [swc-issues]: https://github.com/issues?q=user%3Aswcarpentry
 [swc-lessons]: http://software-carpentry.org/lessons/
 [swc-site]: http://software-carpentry.org/


### PR DESCRIPTION
Links in CONTRIBUTING.md were 404's (previously https://github.com/swcarpentry/FIXME and https://github.com/swcarpentry/FIXME/issues/).