### PR TITLE
remove out of date comment in 07-control-flow.Rmd

### DIFF
--- a/_episodes_rmd/07-control-flow.Rmd
+++ b/_episodes_rmd/07-control-flow.Rmd
@@ -47,9 +47,6 @@ if (condition is true) {
 Say, for example, that we want R to print a message if a variable `x` has a particular value:
 
 ```{r}
-# sample a random number from a Poisson distribution
-# with a mean (lambda) of 8
-
 x <- 8
 
 if (x >= 10) {


### PR DESCRIPTION
removed comments about "Poisson distribution" and "lamda = 8" that we left over when 
`x <- rpois(1, lambda=8)` was changed to `x <- 8` in 
https://github.com/swcarpentry/r-novice-gapminder/commit/f60708b030f3c4479536476c3647080adfee129c

