### PR TITLE
Fix markdown fomatting in episode 1

### DIFF
--- a/_episodes_rmd/01-rstudio-intro.Rmd
+++ b/_episodes_rmd/01-rstudio-intro.Rmd
@@ -101,7 +101,6 @@ interactive R console.
 > RStudio offers you great flexibility in running code from within the editor
 > window. There are buttons, menu choices, and keyboard shortcuts. To run the
 > current line, you can 
-
 > 1. click on the `Run` button above the editor panel, or 
 > 2. select "Run Lines" from the "Code" menu, or 
 > 3. hit <kbd>Ctrl</kbd>+<kbd>Return</kbd> in Windows or Linux 


### PR DESCRIPTION
Remove spurious newline, which was preventing the callout rendering correctly