### PR TITLE
Remove reference to `[]` being a function and tweak.

### DIFF
--- a/_episodes_rmd/06-data-subsetting.Rmd
+++ b/_episodes_rmd/06-data-subsetting.Rmd
@@ -59,10 +59,8 @@ x[1]
 x[4]
 ```
 
-It may look different, but the square brackets operator is a function. For vectors
-(and matrices), it means "get me the nth element".
-
-We can ask for multiple elements at once:
+For vectors
+(and matrices), the square brackets operator means "get me these elements". We can ask for multiple elements at once:
 
 ```{r}
 x[c(1, 3)]


### PR DESCRIPTION
Yes it is a function, but this seems like an awkward spot for a sidebar on how all operators are in fact functions, at this point, learners probably can't appreciate that. So it's just a distraction.

It also seems contradictory to say `[]` means "get me the nth element" when the very next step is to use it to get multiple elements. "get me these elements" works for a single element and also works for logical indexing.