### PR TITLE
Exploring Data Frames -- changed 'human.age' to 'human_age'

### DIFF
--- a/_episodes_rmd/05-data-structures-part2.Rmd
+++ b/_episodes_rmd/05-data-structures-part2.Rmd
@@ -115,14 +115,14 @@ str(cats)
 
 > ## Challenge 1
 > Let's imagine that 1 human year is equivalent to 7 cat years. 
-> 1. Create a vector called `human.age` by multiplying `cats$age` by 7.
-> 2. Convert `human.age` to a factor.
-> 3. Convert `human.age` back to a numeric vector using the `as.numeric()` function. Now divide it by 7 to get the original ages back. Explain what happened.
+> 1. Create a vector called `human_age` by multiplying `cats$age` by 7.
+> 2. Convert `human_age` to a factor.
+> 3. Convert `human_age` back to a numeric vector using the `as.numeric()` function. Now divide it by 7 to get the original ages back. Explain what happened.
 >
 > > ## Solution to Challenge 1
-> > 1. `human.age <- cats$age * 7`
-> > 2. `human.age <- factor(human.age)`. `as.factor(human.age)` works just as well.
-> > 3. `as.numeric(human.age)` yields `1 2 3 4 4` because factors are stored as integers (here, 1:4), each of which is associated with a label (here, 28, 35, 56, and 63). Converting the factor to a numeric vector gives us the underlying integers, not the labels. If we want the original numbers, we need to convert `human.age` to a character vector and then to a numeric vector (why does this work?). This comes up in real life when we accidentally include a character somewhere in a column of a .csv file supposed to only contain numbers, and forget to set `stringsAsFactors=FALSE` when we read in the data.
+> > 1. `human_age <- cats$age * 7`
+> > 2. `human_age <- factor(human_age)`. `as.factor(human_age)` works just as well.
+> > 3. `as.numeric(human_age)` yields `1 2 3 4 4` because factors are stored as integers (here, 1:4), each of which is associated with a label (here, 28, 35, 56, and 63). Converting the factor to a numeric vector gives us the underlying integers, not the labels. If we want the original numbers, we need to convert `human_age` to a character vector and then to a numeric vector (why does this work?). This comes up in real life when we accidentally include a character somewhere in a column of a .csv file supposed to only contain numbers, and forget to set `stringsAsFactors=FALSE` when we read in the data.
 > {: .solution}
 {: .challenge}
 


### PR DESCRIPTION
In 'Exploring Data Frames', changed the name of the vector created in Challenge 1 from 'human.age' to 'human_age'. This should resolve issue #383. @naupaka 
