### PR TITLE
don't evaluate rm() during rendering

### DIFF
--- a/_episodes_rmd/01-rstudio-intro.Rmd
+++ b/_episodes_rmd/01-rstudio-intro.Rmd
@@ -459,14 +459,14 @@ ls
 
 You can use `rm` to delete objects you no longer need:
 
-```{r}
+```{r, eval=FALSE}
 rm(x)
 ```
 
 If you have lots of things in your environment and want to delete all of them,
 you can pass the results of `ls` to the `rm` function:
 
-```{r}
+```{r, eval=FALSE}
 rm(list = ls())
 ```
 


### PR DESCRIPTION
This is causing issues with recent upstream changes to the script building the lessons. Running `rm()` removes variables that are needed by the script.