### PR TITLE
changed to "New Project"; correct link to gapminder_data.csv

### DIFF
--- a/_episodes/02-project-intro.md
+++ b/_episodes/02-project-intro.md
@@ -64,7 +64,7 @@ project.
 >
 > 1. Click the "File" menu button, then "New Project".
 > 2. Click "New Directory".
-> 3. Click "Empty Project".
+> 3. Click "New Project".
 > 4. Type in the name of the directory to store your project, e.g. "my_project".
 > 5. If available, select the checkbox for "Create a git repository."
 > 6. Click the "Create Project" button.

--- a/_episodes/02-project-intro.md
+++ b/_episodes/02-project-intro.md
@@ -144,7 +144,7 @@ one to store the analysis scripts.
 Now we have a good directory structure we will now place/save the data file in the `data/` directory.
 
 > ## Challenge 1
-> Download the gapminder data from [here](https://raw.githubusercontent.com/swcarpentry/r-novice-gapminder/gh-pages/_episodes_rmd/data/gapminder_wide.csv).
+> Download the gapminder data from [here](https://raw.githubusercontent.com/swcarpentry/r-novice-gapminder/gh-pages/_episodes_rmd/data/gapminder_data.csv).
 >
 > 1. Download the file (CTRL + S, right mouse click -> "Save as", or File -> "Save page as")
 > 2. Make sure it's saved under the name `gapminder_data.csv`

--- a/_episodes_rmd/02-project-intro.Rmd
+++ b/_episodes_rmd/02-project-intro.Rmd
@@ -65,7 +65,7 @@ project.
 >
 > 1. Click the "File" menu button, then "New Project".
 > 2. Click "New Directory".
-> 3. Click "Empty Project".
+> 3. Click "New Project".
 > 4. Type in the name of the directory to store your project, e.g. "my_project".
 > 5. If available, select the checkbox for "Create a git repository."
 > 6. Click the "Create Project" button.


### PR DESCRIPTION
In RStudio it is shown "New Project", not "Empty Project".

In the .md file the link is wrong. It links to gapminder_wide.csv. It is correct in the .Rmd file. It is also correct in the Episode Exploring data Frames.