### PR TITLE
Clarify warning vs error of rbind

### DIFF
--- a/_episodes_rmd/05-data-structures-part2.Rmd
+++ b/_episodes_rmd/05-data-structures-part2.Rmd
@@ -87,7 +87,7 @@ newRow <- list("tortoiseshell", 3.3, TRUE, 9)
 cats <- rbind(cats, newRow)
 ```
 
-Looks like our attempt to `rbind` returns a warning.  Recall that, unlike errors, warnings do not necessarily stop a function from performing its intended action.  You can confirm this by taking a look at the `cats` data frame.
+Looks like our attempt to use the `rbind()` function returns a warning.  Recall that, unlike errors, warnings do not necessarily stop a function from performing its intended action.  You can confirm this by taking a look at the `cats` data frame.
 
 ```{r}
 cats

--- a/_episodes_rmd/05-data-structures-part2.Rmd
+++ b/_episodes_rmd/05-data-structures-part2.Rmd
@@ -87,15 +87,23 @@ newRow <- list("tortoiseshell", 3.3, TRUE, 9)
 cats <- rbind(cats, newRow)
 ```
 
+Looks like our attempt to `rbind` returns a warning.  Recall that, unlike errors, warnings do not necessarily stop a function from performing its intended action.  You can confirm this by taking a look at the `cats` data frame.
+
+```{r}
+cats
+```
+
+Notice that not only did we successfully add a new row, but there is `NA` in the column *coats* where we expected "tortoiseshell" to be.  Why did this happen?
+
 ## Factors
 
-Here is another thing to look out for: in a `factor`, each different value represents what is called a `level`. In our case, the `factor` "coat" has 3 levels: "black", "calico", and "tabby". R will only accept values that match one of the levels. If you add a new value, it will become `NA`.
+For an object containing the data type `factor`, each different value represents what is called a `level`. In our case, the `factor` "coat" has 3 levels: "black", "calico", and "tabby". R will only accept values that match one of the levels. If you add a new value, it will become `NA`.
 
 The warning is telling us that we unsuccessfully added "tortoiseshell" to our
 *coat* factor, but 3.3 (a numeric), TRUE (a logical), and 9 (a numeric) were
 successfully added to *weight*, *likes_string*, and *age*, respectively, since
 those variables are not factors. To successfully add a cat with a
-"tortoiseshell" *coat*, add "tortoiseshell" as a *level* of the factor:
+"tortoiseshell" *coat*, add "tortoiseshell" as a possible *level* of the factor:
 
 ```{r}
 levels(cats$coat)


### PR DESCRIPTION
This pull request is intended to resolve #420 by adding some text reflecting on the results of using `rbind` with factors.  By examining the object (`cats`), the learner can note the unusual results following the warning about factor levels (successful `rbind` but introduction of `NA`), which may better set up the subsequent discussion about what factors are.