### PR TITLE
fixed formatting for link to knitr site

### DIFF
--- a/_episodes_rmd/15-knitr-markdown.Rmd
+++ b/_episodes_rmd/15-knitr-markdown.Rmd
@@ -52,7 +52,7 @@ data, you can just re-compile the report and get the new or corrected
 results (versus having to reconstruct figures, paste them into
 a Word document, and further hand-edit various detailed results).
 
-The key R package is `[knitr](http://yihui.name/knitr/)`. It allows you
+The key R package is [knitr](http://yihui.name/knitr/). It allows you
 to create a document that is a mixture of text and chunks of
 code. When the document is processed by `knitr`, chunks of code will
 be executed, and graphs or other results inserted into the final document.


### PR DESCRIPTION
The link to the knitr site was formatted as in-line R code, so reformatted as a link