### PR TITLE
updated scale_x_log10 ggplot option to scale_x_continuous

### DIFF
--- a/_episodes_rmd/08-plot-ggplot2.Rmd
+++ b/_episodes_rmd/08-plot-ggplot2.Rmd
@@ -216,15 +216,10 @@ a large amount of data which is very clustered.
 
 ```{r axis-scale}
 ggplot(data = gapminder, aes(x = gdpPercap, y = lifeExp)) +
-  geom_point(alpha = 0.5) + scale_x_log10()
+  geom_point(alpha = 0.5) + scale_x_continuous(trans="log10")
 ```
 
-The `log10` function applied a transformation to the values of the gdpPercap
-column before rendering them on the plot, so that each multiple of 10 now only
-corresponds to an increase in 1 on the transformed scale, e.g. a GDP per capita
-of 1,000 is now 3 on the y axis, a value of 10,000 corresponds to 4 on the y
-axis and so on. This makes it easier to visualize the spread of data on the
-x-axis.
+The `log10` transformation, using the `scale_x_continuous` function,  applied a transformation to the values of the gdpPercap column before rendering them on the plot, so that each multiple of 10 now only corresponds to an increase in 1 on the transformed scale, e.g. a GDP per capita of 1,000 is now 3 on the y axis, a value of 10,000 corresponds to 4 on the y axis and so on. This makes it easier to visualize the spread of data on the x-axis.  The `scale_x_continuous` function can be used for other transformations, such as exponential, natural logarithm, square roots, and more.
 
 > ## Tip Reminder: Setting an aesthetic to a value instead of a mapping
 >
@@ -236,7 +231,7 @@ We can fit a simple relationship to the data by adding another layer,
 
 ```{r lm-fit}
 ggplot(data = gapminder, aes(x = gdpPercap, y = lifeExp)) +
-  geom_point() + scale_x_log10() + geom_smooth(method="lm")
+  geom_point() + scale_x_continuous(trans="log10") + geom_smooth(method="lm")
 ```
 
 We can make the line thicker by *setting* the **size** aesthetic in the
@@ -244,7 +239,7 @@ We can make the line thicker by *setting* the **size** aesthetic in the
 
 ```{r lm-fit2}
 ggplot(data = gapminder, aes(x = gdpPercap, y = lifeExp)) +
-  geom_point() + scale_x_log10() + geom_smooth(method="lm", size=1.5)
+  geom_point() + scale_x_continuous(trans="log10") + geom_smooth(method="lm", size=1.5)
 ```
 
 There are two ways an *aesthetic* can be specified. Here we *set* the **size**
@@ -268,7 +263,7 @@ variables and their visual representation.
 > >
 > > ```{r ch4a-sol}
 > > ggplot(data = gapminder, aes(x = gdpPercap, y = lifeExp)) +
-> >  geom_point(size=3, color="orange") + scale_x_log10() +
+> >  geom_point(size=3, color="orange") + scale_x_continuous(trans="log10") +
 > >  geom_smooth(method="lm", size=1.5)
 > > ```
 > {: .solution}
@@ -290,7 +285,7 @@ variables and their visual representation.
 > >
 > >```{r ch4b-sol}
 > > ggplot(data = gapminder, aes(x = gdpPercap, y = lifeExp, color = continent)) +
-> > geom_point(size=3, shape=17) + scale_x_log10() +
+> > geom_point(size=3, shape=17) + scale_x_continuous(trans="log10") +
 > > geom_smooth(method="lm", size=1.5)
 > > ```
 > {: .solution}
@@ -340,7 +335,7 @@ are set using the same names we used in the `aes` specification. Thus below
 the color legend title is set using `color = "Continent"`, while the title 
 of a fill legend would be set using `fill = "MyTitle"`. 
 
-```{r theme}
+```{r theme, eval=FALSE}
 ggplot(data = az.countries, aes(x = year, y = lifeExp, color=continent)) +
   geom_line() + facet_wrap( ~ country) +
   labs(
@@ -357,7 +352,8 @@ ggplot(data = az.countries, aes(x = year, y = lifeExp, color=continent)) +
 
 The `ggsave()` function allows you to export a plot created with ggplot. You can specify the dimension and resolution of your plot by adjusting the appropriate arguments (`width`, `height` and `dpi`) to create high quality graphics for publication. In order to save the plot from above, we first assign it to a variable `lifeExp_plot`, then tell `ggsave` to save that plot in `png` format to a directory called `results`. (Make sure you have a `results/` folder in your working directory.)
 
-```{r save}
+
+```{r save, eval=FALSE}
 lifeExp_plot <- ggplot(data = az.countries, aes(x = year, y = lifeExp, color=continent)) +
   geom_line() + facet_wrap( ~ country) +
   labs(
@@ -402,7 +398,7 @@ code to modify!
 > >
 > > ```{r ch5-sol}
 > > ggplot(data = gapminder, aes(x = gdpPercap, fill=continent)) +
-> >  geom_density(alpha=0.6) + facet_wrap( ~ year) + scale_x_log10()
+> >  geom_density(alpha=0.6) + facet_wrap( ~ year) + scale_x_continuous(trans="log10")
 > > ```
 > {: .solution}
 {: .challenge}


### PR DESCRIPTION
Instead of scale_log_10 as an option to transform the plot to logarithmic scale in base 10, I suggest using scale_x_continuous(trans="log10").  Scale_x_continuous is equally intuitively understandable, and it allows the learner to easily use the same function for other transformations such as the natural log, exponential, and so on, without having to learn a new option.

