### PR TITLE
Rstudio updates

### DIFF
--- a/_episodes_rmd/15-knitr-markdown.Rmd
+++ b/_episodes_rmd/15-knitr-markdown.Rmd
@@ -208,6 +208,9 @@ If you know how to write equations in
 $$y = \mu + \sum_{i=1}^p \beta_i x_i + \epsilon$$
 ```
 
+You can review Markdown syntax by navigating to the
+"Markdown Quick Reference" under the "Help" field in the 
+toolbar at the top of RStudio.
 
 ## R code chunks
 
@@ -334,6 +337,10 @@ names, like `fig.path="Figs/cleaning-"` and `fig.path="Figs/analysis-"`.
 > code.
 {: .challenge}
 
+You can review all of the `R` chunk options by navigating to
+the "R Markdown Cheat Sheet" under the "Cheatsheets" section 
+of the "Help" field in the toolbar at the top of RStudio.
+
 
 ## Inline R code
 
@@ -377,6 +384,7 @@ of the file.
 > - [TeX installers for Windows](https://miktex.org/2.9/setup).
 > - [TeX installers for macOS](https://tug.org/mactex).
 {: .callout}
+
 
 
 ## Resources

--- a/_episodes_rmd/15-knitr-markdown.Rmd
+++ b/_episodes_rmd/15-knitr-markdown.Rmd
@@ -178,10 +178,7 @@ with some number of `#` symbols:
 ```
 
 You _compile_ the R Markdown document to an html webpage by clicking
-the "Knit HTML" in the upper-left. And note the little question mark
-next to it; click the question mark and you'll get a "Markdown Quick
-Reference" (with the Markdown syntax) as well to the RStudio
-documentation on R Markdown.
+the "Knit" button in the upper-left.
 
 > ## Challenge
 >
@@ -210,7 +207,6 @@ If you know how to write equations in
 ```
 $$y = \mu + \sum_{i=1}^p \beta_i x_i + \epsilon$$
 ```
-
 
 
 ## R code chunks
@@ -245,7 +241,7 @@ produced them.
 
 ## How things get compiled
 
-When you press the "Knit HTML" button, the R Markdown document is
+When you press the "Knit" button, the R Markdown document is
 processed by `[knitr](http://yihui.name/knitr)` and a plain Markdown
 document is produced (as well as, potentially, a set of figure files): the R code is executed
 and replaced by both the input and the output; if figures are
@@ -369,7 +365,7 @@ this.
 ## Other output options
 
 You can also convert R Markdown to a PDF or a Word document. Click the
-little triangle next to the "Knit HTML" button to get a drop-down
+little triangle next to the "Knit" button to get a drop-down
 menu. Or you could put `pdf_document` or `word_document` in the initial header
 of the file.
 


### PR DESCRIPTION
*Following up on a previous PR (https://github.com/swcarpentry/r-novice-gapminder/pull/486)*

I think some of the text in this lesson was written based on a previous version of the RStudio IDE. This Pull Request has two changes:

1. The new RStudio just has a "Knit" button, not "Knit HTML" as in the lesson.
2. There is no question mark next to the Knit button; instead, the Markdown reference is listed under the Help menu of the toolbar. I also added text to point readers to the R Markdown Cheat Sheet, which is directly accessible from Rstudio
