### PR TITLE
Replace stopifnot() with assert_that() for better error messages

### DIFF
--- a/_episodes_rmd/01-rstudio-intro.Rmd
+++ b/_episodes_rmd/01-rstudio-intro.Rmd
@@ -590,6 +590,7 @@ network). R and RStudio have functionality for managing packages:
 > > install.packages("ggplot2")
 > > install.packages("plyr")
 > > install.packages("gapminder")
+> > install.packages("assertthat")
 > >```
 > {: .solution}
 {: .challenge}

--- a/_episodes_rmd/10-functions.Rmd
+++ b/_episodes_rmd/10-functions.Rmd
@@ -225,6 +225,7 @@ We want to assert the following: `temp` is a numeric vector. We may do that like
 so:
 
 ```{r}
+library(assertthat)
 fahr_to_kelvin <- function(temp) {
   assert_that(is.numeric(temp))
   kelvin <- ((temp - 32) * (5 / 9)) + 273.15
@@ -262,6 +263,7 @@ fahr_to_kelvin(temp = as.factor(32))
 > >
 > >
 > > ```{r}
+> > library(assertthat)
 > > fahr_to_celsius <- function(temp) {
 > >   assert_that(is.numeric(temp))
 > >   temp_k <- fahr_to_kelvin(temp)

--- a/_episodes_rmd/10-functions.Rmd
+++ b/_episodes_rmd/10-functions.Rmd
@@ -7,14 +7,14 @@ questions:
 objectives:
 - "Define a function that takes arguments."
 - "Return a value from a function."
-- "Check argument conditions with `stopifnot()` in functions."
+- "Check argument conditions with `assert_that()` in functions."
 - "Test a function."
 - "Set default values for function arguments."
 - "Explain why we should divide programs into small, single-purpose functions."
 keypoints:
 - "Use `function` to define a new function in R."
 - "Use parameters to pass values into functions."
-- "Use `stopifnot()` to flexibly check function arguments in R."
+- "Use `assert_that()` to flexibly check function arguments in R."
 - "Load functions into programs using `source()`."
 source: Rmd
 ---
@@ -179,7 +179,10 @@ statements because we want to assert some condition is `TRUE` before proceeding.
 They make it easier to debug because they give us a better idea of where the
 errors originate.
 
-### Checking conditions with `stopifnot()`
+[`assertthat`](https://github.com/hadley/assertthat#assertthat) is an R package
+for this purpose. Install and load it as you have learned in previous episodes.
+
+### Checking conditions with `assert_that()`
 
 Let's start by re-examining `fahr_to_kelvin()`, our function for converting
 temperatures from Fahrenheit to Kelvin. It was defined like so:
@@ -209,13 +212,13 @@ fahr_to_kelvin <- function(temp) {
 ```
 
 If we had multiple conditions or arguments to check, it would take many lines
-of code to check all of them. Luckily R provides the convenience function
-`stopifnot()`. We can list as many requirements that should evaluate to `TRUE`;
-`stopifnot()` throws an error if it finds one that is `FALSE`. Listing these
+of code to check all of them. Luckily
+`assert_that()`can be used to check the requirements that should evaluate to `TRUE`;
+`assert_that()` throws an error if it finds one that is `FALSE`. Listing these
 conditions also serves a secondary purpose as extra documentation for the
 function.
 
-Let's try out defensive programming with `stopifnot()` by adding assertions to
+Let's try out defensive programming with `assert_that()` by adding assertions to
 check the input to our function `fahr_to_kelvin()`.
 
 We want to assert the following: `temp` is a numeric vector. We may do that like
@@ -223,7 +226,7 @@ so:
 
 ```{r}
 fahr_to_kelvin <- function(temp) {
-  stopifnot(is.numeric(temp))
+  assert_that(is.numeric(temp))
   kelvin <- ((temp - 32) * (5 / 9)) + 273.15
   return(kelvin)
 }
@@ -253,14 +256,14 @@ fahr_to_kelvin(temp = as.factor(32))
 > > ## Solution to challenge 3
 > >
 > > Extend our previous definition of the function by adding in an explicit call
-> > to `stopifnot()`. Since `fahr_to_celsius()` is a composition of two other
+> > to `assert_that()`. Since `fahr_to_celsius()` is a composition of two other
 > > functions, checking inside here makes adding checks to the two component
 > > functions redundant.
 > >
 > >
 > > ```{r}
 > > fahr_to_celsius <- function(temp) {
-> >   stopifnot(is.numeric(temp))
+> >   assert_that(is.numeric(temp))
 > >   temp_k <- fahr_to_kelvin(temp)
 > >   result <- kelvin_to_celsius(temp_k)
 > >   return(result)


### PR DESCRIPTION
Hello :-)

What are your feeling/ideas/suggestions regarding replacing [`stopifnot()` in ep. 10](https://github.com/swcarpentry/r-novice-gapminder/blob/f3d5c959a39de2b4d9d9f6927523e8a969427004/_episodes_rmd/10-functions.Rmd) with [`assertthat::assert_that()`](https://github.com/hadley/assertthat#assertthat)?

This topic came up during a workshop preparation and is related to https://github.com/swcarpentry/r-novice-gapminder/issues/221. Over in [r-novice-inflammation](https://github.com/swcarpentry/r-novice-inflammation/search?q=stopifnot&unscoped_q=stopifnot), we don't teach it, and [previous plans to do it were decided against](https://github.com/swcarpentry/r-novice-inflammation/commit/a8a0c7326ea41aaae542806b15bb63c3bdecd3bb).

This is a quick draft, feedback welcome!