### PR TITLE
Canonicalize CRAN links

### DIFF
--- a/_episodes_rmd/05-data-structures-part2.Rmd
+++ b/_episodes_rmd/05-data-structures-part2.Rmd
@@ -259,7 +259,7 @@ gapminder <- read.csv("data/gapminder_data.csv")
 > ```
 >
 > * You can read directly from excel spreadsheets without
-> converting them to plain text first by using the [readxl](https://cran.r-project.org/web/packages/readxl/index.html) package.
+> converting them to plain text first by using the [readxl](https://cran.r-project.org/package=readxl) package.
 {: .callout}
 
 Let's investigate gapminder a bit; the first thing we should always do is check

--- a/_episodes_rmd/13-dplyr.Rmd
+++ b/_episodes_rmd/13-dplyr.Rmd
@@ -41,7 +41,7 @@ nasty bugs.
 
 ## The `dplyr` package
 
-Luckily, the [`dplyr`](https://cran.r-project.org/web/packages/dplyr/dplyr.pdf)
+Luckily, the [`dplyr`](https://cran.r-project.org/package=dplyr)
 package provides a number of very useful functions for manipulating dataframes
 in a way that will reduce the above repetition, reduce the probability of making
 errors, and probably even save you some typing. As an added bonus, you might


### PR DESCRIPTION
CRAN [asks people](https://cran.r-project.org/doc/manuals/R-exts.html#Specifying-URLs) to use this URL variant when linking to packages ;-) This PR results from a semi-automatic search-and-replace script and implements their suggestion.