### PR TITLE
Remove color from Transformations & statistics (08)

### DIFF
--- a/_episodes_rmd/08-plot-ggplot2.Rmd
+++ b/_episodes_rmd/08-plot-ggplot2.Rmd
@@ -203,7 +203,7 @@ ggplot2 also makes it easy to overlay statistical models over the data. To
 demonstrate we'll go back to our first example:
 
 ```{r lifeExp-vs-gdpPercap-scatter3, message=FALSE}
-ggplot(data = gapminder, mapping = aes(x = gdpPercap, y = lifeExp, color=continent)) +
+ggplot(data = gapminder, mapping = aes(x = gdpPercap, y = lifeExp)) +
   geom_point()
 ```
 


### PR DESCRIPTION
Per #502 , removing `color=continent` at beginning of Transformations & Statistics section in order to maintain continuity with subsequent portions of the lesson.