### PR TITLE
Update ProjectTemplate code to remove potential conflict

### DIFF
--- a/_episodes_rmd/08-plot-ggplot2.Rmd
+++ b/_episodes_rmd/08-plot-ggplot2.Rmd
@@ -357,6 +357,12 @@ ggplot(data = az.countries, mapping = aes(x = year, y = lifeExp, color=continent
 
 The `ggsave()` function allows you to export a plot created with ggplot. You can specify the dimension and resolution of your plot by adjusting the appropriate arguments (`width`, `height` and `dpi`) to create high quality graphics for publication. In order to save the plot from above, we first assign it to a variable `lifeExp_plot`, then tell `ggsave` to save that plot in `png` format to a directory called `results`. (Make sure you have a `results/` folder in your working directory.)
 
+```{r directory-check, echo = FALSE}
+if (!dir.exists("results")) {
+  dir.create("results")
+}
+```
+
 ```{r save}
 lifeExp_plot <- ggplot(data = az.countries, mapping = aes(x = year, y = lifeExp, color=continent)) +
   geom_line() + facet_wrap( ~ country) +

--- a/_episodes_rmd/16-wrap-up.Rmd
+++ b/_episodes_rmd/16-wrap-up.Rmd
@@ -36,7 +36,7 @@ Keep your project folder structured, organized and tidy, by creating subfolders 
 > ```{r, eval=FALSE}
 > install.packages("ProjectTemplate")
 > library("ProjectTemplate")
-> create.project("../my_project", merge.strategy = "allow.non.conflict")
+> create.project("../my_project_2", merge.strategy = "allow.non.conflict")
 > ```
 >
 > For more information on ProjectTemplate and its functionality visit the


### PR DESCRIPTION
Call to `ProjectTemplate::create.project` will throw error if a project "my_project" already exists in the parent directory. This PR changes the name of the project to "my_project2" in attempt to avoid collision.