### PR TITLE
Fix gapminder link per issue521

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Maintainers:
 * Tom Wright
 * [Naupaka Zimmerman][zimmerman_naupaka]
 
-[gapminder]: http://www.gapminder.org/
+[gapminder]: https://en.wikipedia.org/wiki/Gapminder_Foundation 
 [lesson-example]: https://carpentries.github.io/lesson-example
 [mawdsley_david]: https://carpentries.org/maintainers/#mawds
 [oliver_jeffrey]: https://carpentries.org/maintainers/#jcoliver

--- a/_episodes_rmd/01-rstudio-intro.Rmd
+++ b/_episodes_rmd/01-rstudio-intro.Rmd
@@ -38,7 +38,7 @@ Science is a multi-step process: once you've designed an experiment and collecte
 data, the real fun begins! This lesson will teach you how to start this process using
 R and RStudio. We will begin with raw data, perform exploratory analyses, and learn
 how to plot results graphically. This example starts with a dataset from
-[gapminder.org](https://www.gapminder.org) containing population information for many
+[Gapminder Foundation](https://en.wikipedia.org/wiki/Gapminder_Foundation) containing population information for many
 countries through time. Can you read the data into R? Can you plot the population for
 Senegal? Can you calculate the average income for countries on the continent of Asia?
 By the end of these lessons you will be able to do things like plot the populations


### PR DESCRIPTION
Update link to Gapminder to point to wikipedia page, since gapminder site currently has what looks like formjacking attacks embedded in various images. See issue #521.