### PR TITLE
Fixed broken link caused by misplaced backticks

### DIFF
--- a/_episodes_rmd/15-knitr-markdown.Rmd
+++ b/_episodes_rmd/15-knitr-markdown.Rmd
@@ -292,7 +292,7 @@ produced them.
 ## How things get compiled
 
 When you press the "Knit" button, the R Markdown document is
-processed by `[knitr](http://yihui.name/knitr)` and a plain Markdown
+processed by [`knitr`](http://yihui.name/knitr) and a plain Markdown
 document is produced (as well as, potentially, a set of figure files): the R code is executed
 and replaced by both the input and the output; if figures are
 produced, links to those figures are included.


### PR DESCRIPTION
In Rmarkdown, backticks specifying inline-code formatting take precedence over square brackets used for inserting a hypertext link. Thus the backticks should be inside the square brackets rather than around the entire statement.

Otherwise the knitted document shows the literal string instead of being a clickable link.