### PR TITLE
Make gentler intro for ggplot2 lesson

### DIFF
--- a/_episodes_rmd/08-plot-ggplot2.Rmd
+++ b/_episodes_rmd/08-plot-ggplot2.Rmd
@@ -40,52 +40,66 @@ it is the most effective for creating publication quality
 graphics.
 
 ggplot2 is built on the grammar of graphics, the idea that any plot can be
-expressed from the same set of components: a **data** set, a
-**coordinate system**, and a set of **geoms**--the visual representation of data
-points.
+built from the same set of components: a **data set**,
+**mapping aesthetics**, and graphical **layers**:
 
-The key to understanding ggplot2 is thinking about a figure in layers.
-This idea may be familiar to you if you have used image editing programs like Photoshop, Illustrator, or
-Inkscape.
+* **Data sets** are the data that you, the user, provide.
 
-Let's start off with an example:
+* **Mapping aesthetics** are what connect the data to the graphics.
+They tell ggplot2 how to use your data to affect how the graph looks,
+such as changing what is plotted on the X or Y axis, or the size or
+color of different data points.
 
-```{r lifeExp-vs-gdpPercap-scatter, message=FALSE}
-library("ggplot2")
-ggplot(data = gapminder, mapping = aes(x = gdpPercap, y = lifeExp)) +
-  geom_point()
-```
+* **Layers** are the actual graphical output from ggplot2. Layers
+determine what kinds of plot are shown (scatterplot, histogram, etc.),
+the coordinate system used (rectangular, polar, others), and other
+important aspects of the plot. The idea of layers of graphics may
+be familiar to you if you have used image editing programs
+like Photoshop, Illustrator, or Inkscape.
 
-So the first thing we do is call the `ggplot` function. This function lets R
-know that we're creating a new plot, and any of the arguments we give the
-`ggplot` function are the *global* options for the plot: they apply to all
+Let's start off building an example using the gapminder data from earlier.
+The most basic function is `ggplot`, which lets R know that we're
+creating a new plot. Any of the arguments we give the `ggplot`
+function are the *global* options for the plot: they apply to all
 layers on the plot.
 
-We've passed in two arguments to `ggplot`. First, we tell `ggplot` what data we
-want to show on our figure, in this example the gapminder data we read in
-earlier. For the second argument,  we passed in the `aes` function, which
-tells `ggplot` how variables in the **data** map to *aesthetic* properties of
-the figure, in this case the **x** and **y** locations. Here we told `ggplot` we
-want to plot the "gdpPercap" column of the gapminder data frame on the x-axis, and
-the "lifeExp" column on the y-axis. Notice that we didn't need to explicitly
-pass `aes` these columns (e.g. `x = gapminder[, "gdpPercap"]`), this is because
-`ggplot` is smart enough to know to look in the **data** for that column!
+```{r blank-ggplot, message=FALSE}
+library("ggplot2")
+ggplot(data = gapminder)
+```
 
-By itself, the call to `ggplot` isn't enough to draw a figure:
+Here we called `ggplot` and told it what data we want to show on
+our figure. This is not enough information for `ggplot` to actually
+draw anything. It only creates a blank slate for other elements
+to be added to.
 
-```{r}
+Now we're going to add in the **mapping aesthetics** using the
+`aes` function. `aes` tells `ggplot` how variables in the **data**
+map to *aesthetic* properties of the figure, such as which columns
+of the data should be used for the **x** and **y** locations.
+
+```{r ggplot-with-aes, message=FALSE}
 ggplot(data = gapminder, mapping = aes(x = gdpPercap, y = lifeExp))
 ```
 
-We need to tell `ggplot` how we want to visually represent the data, which we
-do by adding a new **geom** layer. In our example, we used `geom_point`, which
-tells `ggplot` we want to visually represent the relationship between **x** and
-**y** as a scatterplot of points:
+Here we told `ggplot` we want to plot the "gdpPercap" column of the
+gapminder data frame on the x-axis, and the "lifeExp" column on the
+y-axis. Notice that we didn't need to explicitly pass `aes` these
+columns (e.g. `x = gapminder[, "gdpPercap"]`), this is because
+`ggplot` is smart enough to know to look in the **data** for that column!
 
-```{r lifeExp-vs-gdpPercap-scatter2}
+The final part of making our plot is to tell `ggplot` how we want to
+visually represent the data. We do this by adding a new **layer**
+to the plot using one of the **geom** functions.
+
+```{r lifeExp-vs-gdpPercap-scatter, message=FALSE}
 ggplot(data = gapminder, mapping = aes(x = gdpPercap, y = lifeExp)) +
   geom_point()
 ```
+
+Here we used `geom_point`, which tells `ggplot` we want to visually
+represent the relationship between **x** and **y** as a scatterplot of points.
+
 
 > ## Challenge 1
 >
@@ -334,11 +348,11 @@ elements. The x-axis is too cluttered, and the y axis should read
 "Life expectancy", rather than the column name in the data frame.
 
 We can do this by adding a couple of different layers. The **theme** layer
-controls the axis text, and overall text size. Labels for the axes, plot 
+controls the axis text, and overall text size. Labels for the axes, plot
 title and any legend can be set using the `labs` function. Legend titles
 are set using the same names we used in the `aes` specification. Thus below
-the color legend title is set using `color = "Continent"`, while the title 
-of a fill legend would be set using `fill = "MyTitle"`. 
+the color legend title is set using `color = "Continent"`, while the title
+of a fill legend would be set using `fill = "MyTitle"`.
 
 ```{r theme}
 ggplot(data = az.countries, mapping = aes(x = year, y = lifeExp, color=continent)) +


### PR DESCRIPTION
This is in response to Issue #542. The current ggplot2 lesson starts very abruptly and can be confusing to novices. In my teaching, I've found that using a little time to explain the logic of ggplot a bit more helps a lot. I've also found that building up the first graphic piece by piece works better than starting with the finished graphic and then backtracking to explain how it fits together. 

All changes in this pull request are in the first section of the lesson (up to but not including the first challenge). There are two main (and separate) changes that have been made:
1. The introduction to ggplot grammar has been expanded to replace "coordinate system" with "mapping aesthetics" and explain in (slightly) more detail what each component is.
2. The example scatterplot is built up one element at a time (first data, then aesthetics, then geom) rather than all at once.

In my experience these changes make it much easier for learners to understand how ggplot works. The major disadvantage is that it probably adds ~5 minutes of instruction time. 