### PR TITLE
Correct sub- & superscript formatting

### DIFF
--- a/_episodes_rmd/15-knitr-markdown.Rmd
+++ b/_episodes_rmd/15-knitr-markdown.Rmd
@@ -222,7 +222,7 @@ You can make a hyperlink like this:
 
 You can include an image file like this: `![caption](http://url/for/file)`
 
-You can do subscripts (e.g., F~2~) with `F~2` and superscripts (e.g.,
+You can do subscripts (e.g., F~2~) with `F~2~` and superscripts (e.g.,
 F^2^) with `F^2^`.
 
 If you know how to write equations in


### PR DESCRIPTION
This is more of an issue/bug-report, but because of a related fix.

The sub- & superscript examples seem to [not be rendered online](https://swcarpentry.github.io/r-novice-gapminder/15-knitr-markdown/index.html#a-bit-more-markdown), but are rendered when using RStudio's knitr button.

Thus our code is fine here (with the fix), but the lesson template somehow doesn't render it.
