### PR TITLE
Separate R and RStudio download links with unordered bullets

### DIFF
--- a/_episodes_rmd/01-rstudio-intro.Rmd
+++ b/_episodes_rmd/01-rstudio-intro.Rmd
@@ -48,8 +48,8 @@ for all of these countries in under a minute!
 
 Please ensure you have the latest version of R and RStudio installed on your machine. This is important, as some packages used in the workshop may not install correctly (or at all) if R is not up to date.
 
-[Download and install the latest version of R here](https://www.r-project.org/)
-[Download and install RStudio here](https://www.rstudio.com/)
+* [Download and install the latest version of R here](https://www.r-project.org/)
+* [Download and install RStudio here](https://www.rstudio.com/)
 
 ## Introduction to RStudio
 


### PR DESCRIPTION
The links for downloading R and RStudio appear on the same line with no punctuation between them In the [Before Starting the Workshop](http://swcarpentry.github.io/r-novice-gapminder/01-rstudio-intro/#before-starting-the-workshop) section of the first lesson.

I think this could be confusing for users since it looks like one link where there's actually two. Here's a screenshot of the problem with the two links underlined separately in red:

<img width="563" alt="Screenshot 2019-10-07 at 13 09 31" src="https://user-images.githubusercontent.com/18232097/66310455-27e57180-e904-11e9-862a-85f37c1ef182.png">

I think the intention was probably to have these on separate lines or as bullets, since they appear on separate lines in the R Markdown file.

This pull requests adds unordered bullets to separate these instructions onto separate lines. The output looks like this:

<img width="395" alt="Screenshot 2019-10-07 at 13 22 21" src="https://user-images.githubusercontent.com/18232097/66311072-84955c00-e905-11e9-8baa-76c287c20ad6.png">

I've checked the issues and PRs for this problem, but didn't find anything.