### PR TITLE
Update 04-data-structures-part1.Rmd

### DIFF
--- a/_episodes_rmd/04-data-structures-part1.Rmd
+++ b/_episodes_rmd/04-data-structures-part1.Rmd
@@ -123,8 +123,7 @@ complicated our analyses become, all data in R is interpreted as one of these
 basic data types. This strictness has some really important consequences.
 
 A user has added details of another cat. This information is in the file
-`data/feline-data_v2.csv`.
-
+`data/feline-data_v2.csv`, which can be downloaded from [here](https://raw.githubusercontent.com/swcarpentry/r-novice-gapminder/master/_episodes_rmd/data/feline-data_v2.csv). Download the file (CTRL + S, right mouse click -> “Save as”, or File -> “Save page as”) and save it in the `data/` folder within your project.
 
 ```{r, eval=FALSE}
 file.show("data/feline-data_v2.csv")


### PR DESCRIPTION
The file `data/feline-data_v2.csv` is referenced in text and used in the examples, but there is no link given to download the file. This commit adds a link to the file and download instructions. This addresses issue swcarpentry/r-novice-gapminder#572

I also find it odd that `data/feline-data.csv` is created via code at the top of this lessons. Seems like a waste of time typing that in. Why not have folks download this file as well? If there's interest I could add that to this commit or a new one.