### PR TITLE
Instructor Training Checkout

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
-Please delete this line and the text below before submitting your contribution.
+Instructor Training Checkout
 
----
+I edited two typos: one in Subsetting Data and one in Functions. 
 
-Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  
+Furthermore, I would like to add a general comment: 
 
-Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  
+I personally would drop the references to previous shell lessons as R for Reproducible Scientific Analysis is a stand-alone lesson, and references to lessons not necessarily previously taught may make the learner insecure. 
 
----
+For instance (Control Flow section): “We saw for () loops in the shell lessons earlier. »

--- a/_episodes/06-data-subsetting.md
+++ b/_episodes/06-data-subsetting.md
@@ -702,7 +702,7 @@ When one vector is shorter than the other, it gets *recycled*:
 
 In this case R **repeats** `c("a", "c")` as many times as necessary to match `names(x)`, i.e. we get `c("a","c","a","c","a")`. Since the recycled `"a"`
 doesn't match the third element of `names(x)`, the value of `!=` is `TRUE`.
-Because in this case the longer vector length (5) isn't a multiple of the shorter vector length (2), R printed a warning message. If we had been unlucky and `names(x)` had contained six elements, R would *silently* have done the wrong thing (i.e., not what we intended it to do). This recycling rule can can introduce hard-to-find and subtle bugs!
+Because in this case the longer vector length (5) isn't a multiple of the shorter vector length (2), R printed a warning message. If we had been unlucky and `names(x)` had contained six elements, R would *silently* have done the wrong thing (i.e., not what we intended it to do). This recycling rule can introduce hard-to-find and subtle bugs!
 
 The way to get R to do what we really want (match *each* element of the left argument with *all* of the elements of the right argument) it to use the `%in%` operator. The `%in%` operator goes through each element of its left argument, in this case the names of `x`, and asks, "Does this element occur in the second argument?". Here, since we want to *exclude* values, we also need a `!` operator to change "in" to "not in":
 

--- a/_episodes/10-functions.md
+++ b/_episodes/10-functions.md
@@ -72,7 +72,7 @@ statements that are executed when it runs--is contained within curly braces
 (`{}`). The statements in the body are indented by two spaces. This makes the
 code easier to read but does not affect how the code operates.
 
-It is useful to think of creating functions like writing a cookbook. First you define the "ingredients" that your function needs. In this case, we only need one ingredient to use our function: "temp". After we list our ingredients, we then say what we will do with them, in this case, we are taking our ingredient and applying a set of mathmatical operators to it. 
+It is useful to think of creating functions like writing a cookbook. First you define the "ingredients" that your function needs. In this case, we only need one ingredient to use our function: "temp". After we list our ingredients, we then say what we will do with them, in this case, we are taking our ingredient and applying a set of mathematical operators to it. 
 
 When we call the function, the values we pass to it as arguments are assigned to
 those variables so that we can use them inside the function. Inside the


### PR DESCRIPTION
I edited two typos: one in Subsetting Data and one in Functions. 

Furthermore, I would like to add a general comment: I personally would drop the references to previous shell lessons as R for Reproducible Scientific Analysis is a stand-alone lesson, and references to lessons not necessarily previously taught may make the learner insecure. 

For instance (Control Flow section): “We saw for () loops in the shell lessons earlier."