### PR TITLE
Explain object printing behavior

### DIFF
--- a/_episodes_rmd/01-rstudio-intro.Rmd
+++ b/_episodes_rmd/01-rstudio-intro.Rmd
@@ -450,11 +450,24 @@ ls()
 Note here that we didn't give any arguments to `ls`, but we still
 needed to give the parentheses to tell R to call the function.
 
-If we type `ls` by itself, R will print out the source code for that function!
+If we type `ls` by itself, R prints a bunch of code instead of a listing of objects.
 
 ```{r}
 ls
 ```
+
+What's going on here? 
+
+Like everything in R, `ls` is the name of an object, and entering the name of
+an object by itself prints the contents of the object. The object `x` that we
+created earlier contains `r x`:
+
+```{r}
+x
+```
+
+The object `ls` contains the R code that makes the ls function work! We'll talk
+more about how functions work and start writing our own later.
 
 You can use `rm` to delete objects you no longer need:
 

--- a/_episodes_rmd/01-rstudio-intro.Rmd
+++ b/_episodes_rmd/01-rstudio-intro.Rmd
@@ -466,7 +466,7 @@ created earlier contains `r x`:
 x
 ```
 
-The object `ls` contains the R code that makes the ls function work! We'll talk
+The object `ls` contains the R code that makes the `ls` function work! We'll talk
 more about how functions work and start writing our own later.
 
 You can use `rm` to delete objects you no longer need:

--- a/_episodes_rmd/01-rstudio-intro.Rmd
+++ b/_episodes_rmd/01-rstudio-intro.Rmd
@@ -605,7 +605,7 @@ network). R and RStudio have functionality for managing packages:
 > >```
 > >
 > > An alternate solution, to install multiple packages with a single `install.packages()` command is:
-> > ```{r ch5-sol, eval=FALSE}
+> > ```{r ch5-sol2, eval=FALSE}
 > > install.packages(c("ggplot2", "plyr", "gapminder"))
 > >```
 > {: .solution}


### PR DESCRIPTION
Added an explanation of why `ls` without parens prints the contents of the ls object.

This should fix issue #623 

`make serve` didn't want to render until I renamed a duplicate code block in one of the challenge solutions. 

