### PR TITLE
Corrections about command output

### DIFF
--- a/_episodes_rmd/05-data-structures-part2.Rmd
+++ b/_episodes_rmd/05-data-structures-part2.Rmd
@@ -87,13 +87,12 @@ newRow <- list("tortoiseshell", 3.3, TRUE, 9)
 cats <- rbind(cats, newRow)
 ```
 
-Looks like our attempt to use the `rbind()` function returns a warning.  Recall that, unlike errors, warnings do not necessarily stop a function from performing its intended action.  You can confirm this by taking a look at the `cats` data frame.
+In earlier versions of R, the above use of the `rbind()` function used to returned a warning.  Recall that, unlike errors, warnings do not necessarily stop a function from performing its intended action.  You can confirm this by taking a look at the `cats` data frame.
 
 ```{r}
 cats
 ```
 
-Notice that not only did we successfully add a new row, but there is `NA` in the column *coats* where we expected "tortoiseshell" to be.  Why did this happen?
 
 ## Factors
 


### PR DESCRIPTION
Corrections: 

1. Updating information about a warning that is not actually produced in the current version of R. Edit: 'In earlier versions of R, the above use of the `rbind()` function ...'

2. Delete notice about an NA that is not actually produced in the current version of R. Notice was: 'Notice that not only did we successfully add a new row, but there is `NA` in the column *coats* where we expected "tortoiseshell" to be.  Why did this happen?'
