### PR TITLE
make lesson suitable for teaching with locally-built (serverless) pages

### DIFF
--- a/_episodes_rmd/10-functions.Rmd
+++ b/_episodes_rmd/10-functions.Rmd
@@ -68,17 +68,17 @@ fahr_to_kelvin <- function(temp) {
 
 We define `fahr_to_kelvin()` by assigning it to the output of `function`. The
 list of argument names are contained within parentheses.   Next, the
-[body]({{ page.root }}/reference/#function-body) of the function--the
+[body]({{ page.root }}/reference.html#function-body) of the function--the
 statements that are executed when it runs--is contained within curly braces
 (`{}`). The statements in the body are indented by two spaces. This makes the
 code easier to read but does not affect how the code operates.
 
-It is useful to think of creating functions like writing a cookbook. First you define the "ingredients" that your function needs. In this case, we only need one ingredient to use our function: "temp". After we list our ingredients, we then say what we will do with them, in this case, we are taking our ingredient and applying a set of mathematical operators to it. 
+It is useful to think of creating functions like writing a cookbook. First you define the "ingredients" that your function needs. In this case, we only need one ingredient to use our function: "temp". After we list our ingredients, we then say what we will do with them, in this case, we are taking our ingredient and applying a set of mathematical operators to it.
 
 When we call the function, the values we pass to it as arguments are assigned to
 those variables so that we can use them inside the function. Inside the
 function, we use a [return
-statement]({{ page.root }}/reference/#return-statement) to send a result back to
+statement]({{ page.root }}/reference.html#return-statement) to send a result back to
 whoever asked for it.
 
 > ## Tip
@@ -284,7 +284,7 @@ calcGDP <- function(dat) {
 ```
 
 We define `calcGDP()` by assigning it to the output of `function`. The list of
-argument names are contained within parentheses. Next, the body of the function 
+argument names are contained within parentheses. Next, the body of the function
 -- the statements executed when you call the function -- is contained within
 curly braces (`{}`).
 
@@ -333,8 +333,8 @@ source("functions/functions-lesson.R")
 
 Ok, so there's a lot going on in this function now. In plain English, the
 function now subsets the provided data by year if the year argument isn't empty,
-then subsets the result by country if the country argument isn't empty. Then it 
-calculates the GDP for whatever subset emerges from the previous two steps. The 
+then subsets the result by country if the country argument isn't empty. Then it
+calculates the GDP for whatever subset emerges from the previous two steps. The
 function then adds the GDP as a new column to the subsetted data and returns
 this as the final result. You can see that the output is much more informative
 than a vector of numbers.
@@ -378,7 +378,7 @@ take on those values unless the user specifies otherwise.
 ```
 
 Here, we check whether each additional argument is set to `null`, and whenever
-they're not `null` overwrite the dataset stored in `dat` with a subset given by 
+they're not `null` overwrite the dataset stored in `dat` with a subset given by
 the non-`null` argument.
 
 Building these conditionals into the function makes it more flexible for later.
@@ -423,7 +423,7 @@ arguments.
 
 Finally, we calculated the GDP on our new subset, and created a new data frame
 with that column added. This means when we call the function later we can see
-the context for the returned GDP values, which is much better than in our first 
+the context for the returned GDP values, which is much better than in our first
 attempt where we got a vector of numbers.
 
 > ## Challenge 4
@@ -527,4 +527,3 @@ attempt where we got a vector of numbers.
 
 [roxygen2]: http://cran.r-project.org/web/packages/roxygen2/vignettes/rd.html
 [testthat]: http://r-pkgs.had.co.nz/tests.html
-

--- a/_extras/about.md
+++ b/_extras/about.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: About
-permalink: /about/
 ---
 {% include carpentries.html %}

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Discussion
-permalink: /discuss/
 ---
 Please see [our other R lesson][r-gap] for a different presentation of these concepts.
 

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: "Instructor Notes"
-permalink: /guide/
 ---
 
 ## Timing
@@ -15,7 +13,7 @@ not).
 
 The lesson contains much more material than can be taught in a day.
 Instructors will need to pick an appropriate subset of episodes to use
-in a standard one day course. 
+in a standard one day course.
 
 Some suggested paths through the material are:
 

--- a/reference.md
+++ b/reference.md
@@ -1,6 +1,5 @@
 ---
 layout: reference
-root: .
 ---
 
 ## Reference

--- a/setup.md
+++ b/setup.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Setup
-root: .
 ---
 
 This lesson assumes you have R and RStudio installed on your computer.


### PR DESCRIPTION
See discussion here for more background: https://github.com/datacarpentry/datacarpentry.github.io/issues/542

In short, some Carpentries lessons use the path `/guide/` for their Instructor Notes page and others use `/guide/index.html` (the default defined in `_config.yml`). This PR removes permalinks with a trailing slash from the YAML front matter of the Instructor Notes (`_extras/guide.md`) and other Extras files, consistent with new lessons created with [the lesson template](https://github.com/carpentries/styles/). Although there's no functional difference in the online versions of the lesson pages, pages with a trailing slash in the permalink will result in **broken links in the version of the lesson built locally**. We'd like local builds to be usable e.g. in workshops taking place at locations with limited or unreliable Internet access. 

Keeping the paths to these files consistent will also help us avoid broken links on the [Software Carpentry Lessons page](https://software-carpentry.org/lessons/), and ensure that equivalent paths in new lessons created with the template are consistent with previously-developed lessons like this one.

I did a sweep through the lesson and adjusted internal links as part of this PR. If and when this is merged, I'll also make sure the link on https://software-carpentry.org/lessons/ to the Instructor Notes page isn't broken, and make another sweep through the lesson pages too. 

Finally, I also removed the `layout` field from several pages, as the default layout is already set for Episodes and Extras pages in `_config.yml`.