### PR TITLE
Add CC BY 4.0 link to _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,6 +44,7 @@ template_repo: "https://github.com/carpentries/styles"
 training_site: "https://carpentries.github.io/instructor-training"
 workshop_repo: "https://github.com/carpentries/workshop-template"
 workshop_site: "https://carpentries.github.io/workshop-template"
+cc_by_human: "https://creativecommons.org/licenses/by/4.0/"
 
 # Surveys.
 pre_survey: "https://www.surveymonkey.com/r/swc_pre_workshop_v1?workshop_id="


### PR DESCRIPTION
_config.yml did not have definition of CC BY 4.0 license link (but bin/boilerplate/_config.yml did). Added definition to _config.yml so link is correctly resolved on footers of pages.