### PR TITLE
Fix issues from forwarding default values to install.packages explicitly

### DIFF
--- a/bin/dependencies.R
+++ b/bin/dependencies.R
@@ -1,13 +1,26 @@
 install_required_packages <- function(lib = NULL, repos = getOption("repos", default = c(CRAN = "https://cran.rstudio.com/"))) {
-
-  if (is.null(lib)) {
-    lib <- .libPaths()
+  
+  # The option 'repos' might be set to a special value which confuses
+  # install.packages if it is forwarded explicitly. See ?options for docs of 
+  # the repos option.
+  if(identical(repos, "@CRAN@") && !interactive()){
+    options(repos = c(CRAN = "https://cran.rstudio.com/"))
+    repos <- getOption("repos")
   }
 
-  message("lib paths: ", paste(lib, collapse = ", "))
+  if (is.null(lib)) {
+    lib2 <- .libPaths()
+  }else{
+    # If the lib= argument is provided to install.packages(), all of the
+    # specified folders must be readable. Thus, forward NULL to install.packages
+    # when it is provided to this function.
+    lib2 <- lib
+  }
+
+  message("lib paths: ", paste(lib2, collapse = ", "))
   missing_pkgs <- setdiff(
     c("rprojroot", "desc", "remotes", "renv"),
-    rownames(installed.packages(lib.loc = lib))
+    rownames(installed.packages(lib.loc = lib2))
   )
 
   install.packages(missing_pkgs, lib = lib, repos = repos)


### PR DESCRIPTION
This commit fixed two errors with tooling that arose as I tried to clone
and make the project on my fresh R 4.0.3 installation on Arch Linux.

If install.packages is called with an explicit lib= argument, it expects all
given folders to be readable, which is not the case if the argument is not
provided.

If the repos= argument is not given to install.packages, it can be the special
value @CRAN@, but not if repos= is specified explicitly.
`getOptions(..., default=...)` does not catch this b/c the option is not NULL
but has a special value

