### PR TITLE
update reconcile text describing scale log10 transformation with plot

### DIFF
--- a/_episodes_rmd/08-plot-ggplot2.Rmd
+++ b/_episodes_rmd/08-plot-ggplot2.Rmd
@@ -216,12 +216,7 @@ ggplot(data = gapminder, mapping = aes(x = gdpPercap, y = lifeExp)) +
   geom_point(alpha = 0.5) + scale_x_log10()
 ```
 
-The `log10` function applied a transformation to the values of the gdpPercap
-column before rendering them on the plot, so that each multiple of 10 now only
-corresponds to an increase in 1 on the transformed scale, e.g. a GDP per capita
-of 1,000 is now 3 on the x axis, a value of 10,000 corresponds to 4 on the x
-axis and so on. This makes it easier to visualize the spread of data on the
-x-axis.
+The `scale_x_log10` function applied a transformation to the coordinate system of the plot, so that each multiple of 10 is evenly spaced from left to right. For example, a GDP per capita of 1,000 is the same horizontal distance away from a value of 10,000 as the 10,000 value is from 100,000. This helps to visualize the spread of the data along the x-axis.
 
 > ## Tip Reminder: Setting an aesthetic to a value instead of a mapping
 >


### PR DESCRIPTION
This pull request follows from issue #688  and revises a figure description in episode 08. The old description mentions a function name that is not used in the example above (log10 versus scale_x_log10. The new description includes the scale_x_log10 function name and tries to clarify what the function does.

