### PR TITLE
fixes gap wide typo and adds quotes to title

### DIFF
--- a/_episodes_rmd/14-tidyr.Rmd
+++ b/_episodes_rmd/14-tidyr.Rmd
@@ -1,5 +1,5 @@
 ---
-title: Data frame Manipulation with tidyr
+title: "Data frame Manipulation with tidyr"
 teaching: 30
 exercises: 15
 questions:
@@ -33,7 +33,7 @@ gapminder <- read.csv("data/gapminder_data.csv", header = TRUE, stringsAsFactors
 #     separate(ID_var,into = c('continent','country'),sep = '_')
 #
 # #write our the .csv so students can use it
-# write.csv(gap_wide_betterID,"data/gapminder_wide.csv",row.names = FALSE)
+# write.csv(gap_wide,"data/gapminder_wide.csv",row.names = FALSE)
 
 #load the "student" data
 gap_wide <- read.csv("data/gapminder_wide.csv", header = TRUE, stringsAsFactors = FALSE)


### PR DESCRIPTION
A second attempt at fixing a small typo, changing `gap_wide_betterID` at line 36 to `gap_wide` to write the correct variable to the .csv file. As suggested in the comment on the previous pull request #691  I also added quotes to the tittle and pulled against the master branch this time. I did not use styler to style anything this time as it seemed to introduce some problems. Hope this fixes the issues and thanks for your patience. 