### PR TITLE
Added %in% operator to /reference.html

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -162,6 +162,7 @@ behaviour of R).
    additional tests, and `else` to provide a default
  - The bodies of the branches of conditional statements must be indented.
  - Use `==` to test for equality.
+ - `%in%` will return a `TRUE`/`FALSE` indicating if there is a match between an element and a vector.
  - `X && Y` is only true if both X and Y are `TRUE`.
  - `X || Y` is true if either X or Y, or both, are `TRUE`.
  - Zero is considered `FALSE`; all other numbers are considered `TRUE`


### PR DESCRIPTION
Added  definition of `%in% operator to the `reference` page. 
Mentioned offhand in #603.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
