### PR TITLE
Remove unnecessary dot from facet_grid

### DIFF
--- a/_episodes_rmd/11-writing-data.Rmd
+++ b/_episodes_rmd/11-writing-data.Rmd
@@ -74,7 +74,7 @@ Open up this document and have a look.
 > >   geom_line() +
 > >   theme(legend.position = "none")
 > > p
-> > p + facet_grid(. ~continent)
+> > p + facet_grid(~continent)
 > > dev.off()
 > > ```
 > {: .solution}


### PR DESCRIPTION
Dot is not needed and its use is not introduced earlier in the lesson materials. Removed for simplicity.

Addresses issue #721. 