### PR TITLE
Fix output of ls() function in Lesson 1 RStudio intro

### DIFF
--- a/_episodes_rmd/01-rstudio-intro.Rmd
+++ b/_episodes_rmd/01-rstudio-intro.Rmd
@@ -448,6 +448,16 @@ There are a few useful commands you can use to interact with the R session.
 ls()
 ```
 ```{r echo=FALSE}
+# If `ls()` is left to run by itself when rendering this Rmd document (as would
+# happen if the code chunk above was evaluated), the output would contain extra
+# items ("args", "dest_md", "op", "src_md") that people following the lesson
+# would not see in their own session.
+#
+# This probably comes from the way the md episodes are generated when the
+# lesson website is built. The solution below uses a temporary environment to
+# mimick what the learners should observe when running `ls()` on their
+# machines.
+
 temp.env <- new.env()
 temp.env$x <- x
 temp.env$y <- y

--- a/_episodes_rmd/01-rstudio-intro.Rmd
+++ b/_episodes_rmd/01-rstudio-intro.Rmd
@@ -444,8 +444,15 @@ There are a few useful commands you can use to interact with the R session.
 `ls` will list all of the variables and functions stored in the global environment
 (your working R session):
 
-```{r}
+```{r eval=FALSE}
 ls()
+```
+```{r echo=FALSE}
+temp.env <- new.env()
+temp.env$x <- x
+temp.env$y <- y
+ls(temp.env)
+rm(temp.env)
 ```
 
 > ## Tip: hidden objects


### PR DESCRIPTION
I noticed that the output of the `ls()` function in Lesson 1 (RStudio intro) presently contains a number of extra items (`args`, `dest_md`, `op`, `src_rmd`) that learners shouldn't see on their end if following along in the lesson. This probably comes from the usage of the [`generate_md_episodes()`](https://github.com/swcarpentry/r-novice-gapminder/blob/6c0b1812d9b04c95ad8176ae18eb34a9d86ea65a/bin/generate_md_episodes.R) function, as noted in discussion of #178. The relevant code is on [line 448](https://github.com/swcarpentry/r-novice-gapminder/blob/4b5dbd88b97379f97c8c6a54762fe6461e1e8260/_episodes_rmd/01-rstudio-intro.Rmd#L448) of the Lesson 1 Rmd file.

I've implemented a surface-level solution by defining a temporary environment that contains only the variables that learners should have on their end (`x` and `y`) and using this to generate the `ls()` output. This doesn't address the root of the issue, but at least should align the rendered lesson with what learners should be seeing on their end.