### PR TITLE
Replace deprecated "by" aes with "group"

### DIFF
--- a/_episodes_rmd/08-plot-ggplot2.Rmd
+++ b/_episodes_rmd/08-plot-ggplot2.Rmd
@@ -150,19 +150,19 @@ Instead of adding a `geom_point` layer, we've added a `geom_line` layer.
 However, the result doesn't look quite as we might have expected: it seems to be jumping around a lot in each continent. Let's try to separate the data by country, plotting one line for each country:
 
 ```{r lifeExp-line-by}
-ggplot(data = gapminder, mapping = aes(x=year, y=lifeExp, by=country, color=continent)) +
+ggplot(data = gapminder, mapping = aes(x=year, y=lifeExp, group=country, color=continent)) +
   geom_line()
 ```
 
 
-We've added the **by** *aesthetic*, which tells `ggplot` to draw a line for each
+We've added the **group** *aesthetic*, which tells `ggplot` to draw a line for each
 country.
 
 But what if we want to visualize both lines and points on the plot? We can
 add another layer to the plot:
 
 ```{r lifeExp-line-point}
-ggplot(data = gapminder, mapping = aes(x=year, y=lifeExp, by=country, color=continent)) +
+ggplot(data = gapminder, mapping = aes(x=year, y=lifeExp, group=country, color=continent)) +
   geom_line() + geom_point()
 ```
 
@@ -171,7 +171,7 @@ this example, the points have been drawn *on top of* the lines. Here's a
 demonstration:
 
 ```{r lifeExp-layer-example-1}
-ggplot(data = gapminder, mapping = aes(x=year, y=lifeExp, by=country)) +
+ggplot(data = gapminder, mapping = aes(x=year, y=lifeExp, group=country)) +
   geom_line(mapping = aes(color=continent)) + geom_point()
 ```
 
@@ -195,7 +195,7 @@ lines.
 > > The lines now get drawn over the points!
 > >
 > > ```{r ch3-sol, fig.alt = "Scatter plot of life expectancy vs GDP per capita with a trend line summarising the relationship between variables. The plot illustrates the possibilities for styling visualisations in ggplot2 with data points enlarged, coloured orange, and displayed without transparency."}
-> > ggplot(data = gapminder, mapping = aes(x=year, y=lifeExp, by=country)) +
+> > ggplot(data = gapminder, mapping = aes(x=year, y=lifeExp, group=country)) +
 > >  geom_point() + geom_line(mapping = aes(color=continent))
 > > ```
 > >


### PR DESCRIPTION
The "by" aesthetic in ggplot2 is no longer supported. Although it still works, it throws a warning like: 
`> ggplot(gapminder, aes(x=year,y=lifeExp)) +
   geom_point(alpha=0.5) +
   scale_x_log10() +
   geom_line(aes(color=continent, by=country)) 
Warning message:
In geom_line(aes(color = continent, by = country)) :
  Ignoring unknown aesthetics: by`

I can't find any documentation in the official reference (e.g. https://ggplot2.tidyverse.org/reference/index.html#aesthetics) for `by`. Instead, `group` is used.

I tried to update all code chunks with the `by` aesthetic and also change related text where I found it. I tried to search the remainder of the lessons and didn't find it anywhere.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
