### PR TITLE
Add spaces between list and title

### DIFF
--- a/episodes/15-knitr-markdown.Rmd
+++ b/episodes/15-knitr-markdown.Rmd
@@ -120,9 +120,11 @@ and you make things *italics* by using underscores, like this:
 `_italics_`.
 
 You can make a bulleted list by writing a list with hyphens or
-asterisks, like this:
+asterisks with a space between the list and other text, like this:
 
 ```
+A list:
+
 * bold with double-asterisks
 * italics with underscores
 * code-type font with backticks
@@ -131,6 +133,8 @@ asterisks, like this:
 or like this:
 
 ```
+A second list:
+
 - bold with double-asterisks
 - italics with underscores
 - code-type font with backticks


### PR DESCRIPTION
Changed list description to clarify that to render correctly, there needs to be an empty line between some text and a list.

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

---
