### PR TITLE
clarify instructions to set working directory

### DIFF
--- a/episodes/02-project-intro.Rmd
+++ b/episodes/02-project-intro.Rmd
@@ -232,8 +232,7 @@ You can check the current working directory with the `getwd()` command, or by us
 You can change the working directory with `setwd()`, or by using RStudio menus.
 
 1. In the console, type `setwd("data")` and hit Enter. Type `getwd()` and hit Enter to see the new working directory.
-2. In the menus at the top of the RStudio window, click the "Session" menu button, and then select "Set Working Directory" and then "Choose Directory".
-3. In the windows navigator that opens, navigate back to the project directory, and click "Open". Note that a `setwd` command will automatically appear in the console.
+2. In the menus at the top of the RStudio window, click the "Session" menu button, and then select "Set Working Directory" and then "Choose Directory". Next, in the windows navigator that opens, navigate back to the project directory, and click "Open". Note that a `setwd` command will automatically appear in the console.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 


### PR DESCRIPTION
In [this challenge to set the working directory](https://swcarpentry.github.io/r-novice-gapminder/02-project-intro.html#challenge-5) two options are given --  to use the `setwd()` command or to use the option in the `Sessions` menu. 

There are two steps in using the `Sessions` menu.  The second step is displayed as a third item in the list.  This PR puts both steps in the same list item.