### PR TITLE
Update 05-data-structures-part2.Rmd to fix broken links to gapminder_data.csv

### DIFF
--- a/episodes/05-data-structures-part2.Rmd
+++ b/episodes/05-data-structures-part2.Rmd
@@ -204,14 +204,14 @@ gapminder <- read.csv("data/gapminder_data.csv")
   The `read.csv` function can then be executed to read the downloaded file from the download location, for example,
 
 ```{r, eval=FALSE, echo=TRUE}
-download.file("https://raw.githubusercontent.com/swcarpentry/r-novice-gapminder/gh-pages/_episodes_rmd/data/gapminder_data.csv", destfile = "data/gapminder_data.csv")
+download.file("https://raw.githubusercontent.com/swcarpentry/r-novice-gapminder/main/episodes/data/gapminder_data.csv", destfile = "data/gapminder_data.csv")
 gapminder <- read.csv("data/gapminder_data.csv")
 ```
 
 - Alternatively, you can also read in files directly into R from the Internet by replacing the file paths with a web address in `read.csv`. One should note that in doing this no local copy of the csv file is first saved onto your computer. For example,
 
 ```{r, eval=FALSE, echo=TRUE}
-gapminder <- read.csv("https://raw.githubusercontent.com/swcarpentry/r-novice-gapminder/gh-pages/_episodes_rmd/data/gapminder_data.csv")
+gapminder <- read.csv("https://raw.githubusercontent.com/swcarpentry/r-novice-gapminder/main/episodes/data/gapminder_data.csv")
 ```
 
 - You can read directly from excel spreadsheets without


### PR DESCRIPTION
In the Realistic example section, the links to download gapminder_data.csv were broken. 

I replaced the old link (https://raw.githubusercontent.com/swcarpentry/r-novice-gapminder/gh-pages/_episodes_rmd/data/gapminder_data.csv) with the new working tested link (https://raw.githubusercontent.com/swcarpentry/r-novice-gapminder/main/episodes/data/gapminder_data.csv) on two occasions in episode 05-data-structures-part2.Rmd
