### PR TITLE
Remove reliance on implicit df behavior, #819

### DIFF
--- a/episodes/13-dplyr.Rmd
+++ b/episodes/13-dplyr.Rmd
@@ -29,9 +29,9 @@ data by a certain variable(s), or we even calculate summary statistics. We can
 do these operations using the normal base R operations:
 
 ```{r}
-mean(gapminder[gapminder$continent == "Africa", "gdpPercap"])
-mean(gapminder[gapminder$continent == "Americas", "gdpPercap"])
-mean(gapminder[gapminder$continent == "Asia", "gdpPercap"])
+mean(gapminder$gdpPercap[gapminder$continent == "Africa"])
+mean(gapminder$gdpPercap[gapminder$continent == "Americas"])
+mean(gapminder$gdpPercap[gapminder$continent == "Asia"])
 ```
 
 But this isn't very *nice* because there is a fair bit of repetition. Repeating


### PR DESCRIPTION
Closes #819 

The example I changed relied on implicit behavior of dataframes (which is often better to avoid and doesn't work on tibbles) so I made a slight change to the example that results in the same output but doesn't rely on the implicit dataframe behavior of converting a one column dataframe into a vector.
