### PR TITLE
Remove unwanted R code

### DIFF
--- a/episodes/05-data-structures-part2.Rmd
+++ b/episodes/05-data-structures-part2.Rmd
@@ -138,14 +138,6 @@ cats <- rbind(cats, cats)
 cats
 ```
 
-But now the row names are unnecessarily complicated. We can remove the rownames,
-and R will automatically re-name them sequentially:
-
-```{r}
-rownames(cats) <- NULL
-cats
-```
-
 :::::::::::::::::::::::::::::::::::::::  challenge
 
 ## Challenge 1

--- a/episodes/05-data-structures-part2.Rmd
+++ b/episodes/05-data-structures-part2.Rmd
@@ -390,7 +390,7 @@ The object `gapminder` is a data frame with columns
 - Use `cbind()` to add a new column to a data frame.
 - Use `rbind()` to add a new row to a data frame.
 - Remove rows from a data frame.
-- Use `str()`, `summary()`, `nrow()`, `ncol()`, `dim()`, `colnames()`, `rownames()`, `head()`, and `typeof()` to understand the structure of a data frame.
+- Use `str()`, `summary()`, `nrow()`, `ncol()`, `dim()`, `colnames()`, `head()`, and `typeof()` to understand the structure of a data frame.
 - Read in a csv file using `read.csv()`.
 - Understand what `length()` of a data frame represents.
 


### PR DESCRIPTION
In the episode exploring data frames (https://swcarpentry.github.io/r-novice-gapminder/05-data-structures-part2.html), renaming row names is unnecessary as R re-names them sequentially. So, in the section 'Append to a data frame', the following code snippet can be removed.

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._
Closes #873

_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._


_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
