### PR TITLE
Update/improve links to "Other great resources" in two episodes

### DIFF
--- a/episodes/13-dplyr.Rmd
+++ b/episodes/13-dplyr.Rmd
@@ -470,10 +470,10 @@ lifeExp_2countries_bycontinents <- gapminder %>%
 
 ## Other great resources
 
-- [R for Data Science](https://r4ds.had.co.nz/)
-- [Data Wrangling Cheat sheet](https://www.rstudio.com/wp-content/uploads/2015/02/data-wrangling-cheatsheet.pdf)
-- [Introduction to dplyr](https://dplyr.tidyverse.org/)
-- [Data wrangling with R and RStudio](https://www.rstudio.com/resources/webinars/data-wrangling-with-r-and-rstudio/)
+- [R for Data Science](https://r4ds.hadley.nz/) (online book)
+- [Data Wrangling Cheat sheet](https://www.rstudio.com/wp-content/uploads/2015/02/data-wrangling-cheatsheet.pdf) (pdf file)
+- [Introduction to dplyr](https://dplyr.tidyverse.org/) (online documentation)
+- [Data wrangling with R and RStudio](https://www.rstudio.com/resources/webinars/data-wrangling-with-r-and-rstudio/) (online video)
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 

--- a/episodes/14-tidyr.Rmd
+++ b/episodes/14-tidyr.Rmd
@@ -307,10 +307,10 @@ There and back again!
 
 ## Other great resources
 
-- [R for Data Science](https://r4ds.had.co.nz/index.html)
-- [Data Wrangling Cheat sheet](https://www.rstudio.com/wp-content/uploads/2015/02/data-wrangling-cheatsheet.pdf)
-- [Introduction to tidyr](https://cran.r-project.org/web/packages/tidyr/vignettes/tidy-data.html)
-- [Data wrangling with R and RStudio](https://www.rstudio.com/resources/webinars/data-wrangling-with-r-and-rstudio/)
+- [R for Data Science](https://r4ds.hadley.nz/) (online book)
+- [Data Wrangling Cheat sheet](https://www.rstudio.com/wp-content/uploads/2015/02/data-wrangling-cheatsheet.pdf) (pdf file)
+- [Introduction to tidyr](https://cran.r-project.org/web/packages/tidyr/vignettes/tidy-data.html) (online documentation)
+- [Data wrangling with R and RStudio](https://www.rstudio.com/resources/webinars/data-wrangling-with-r-and-rstudio/) (online video)
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 


### PR DESCRIPTION
Closes #856.

In the "Other great resources" links in two episodes:

- fixed the link to "R for Data Science" to point to the latest edition
- added a short description for each link (e.g. book/pdf file/online doc/video)
