### PR TITLE
Proposed Update to package install at 01-rstudio-intro.Rmd

### DIFF
--- a/episodes/01-rstudio-intro.Rmd
+++ b/episodes/01-rstudio-intro.Rmd
@@ -705,6 +705,16 @@ install.packages(c("ggplot2", "plyr", "gapminder"))
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+::::::::::::::::::::::::::::::::::::: instructor
+
+When installing ggplot2, it may be required on some users to use the dependencies flag as a result of lazy loading affecting the install. This is an explicit solution to address this bug. Such that:
+
+```{r ch5-sol, eval=FALSE}
+install.packages("ggplot2", dependencies = TRUE)
+```
+
+:::::::::::::::::::::::::::::::::::::::::::::::::
+
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
 - Use RStudio to write and run R programs.

--- a/episodes/01-rstudio-intro.Rmd
+++ b/episodes/01-rstudio-intro.Rmd
@@ -707,9 +707,9 @@ install.packages(c("ggplot2", "plyr", "gapminder"))
 
 ::::::::::::::::::::::::::::::::::::: instructor
 
-When installing ggplot2, it may be required on some users to use the dependencies flag as a result of lazy loading affecting the install. This is an explicit solution to address this bug. Such that:
+When installing ggplot2, it may be required for some users to use the dependencies flag as a result of lazy loading affecting the install. This is an explicit solution to address this bug. Such that:
 
-```{r ch5-sol, eval=FALSE}
+```{r ch5-sol3, eval=FALSE}
 install.packages("ggplot2", dependencies = TRUE)
 ```
 

--- a/episodes/01-rstudio-intro.Rmd
+++ b/episodes/01-rstudio-intro.Rmd
@@ -707,7 +707,7 @@ install.packages(c("ggplot2", "plyr", "gapminder"))
 
 ::::::::::::::::::::::::::::::::::::: instructor
 
-When installing ggplot2, it may be required for some users to use the dependencies flag as a result of lazy loading affecting the install. This is an explicit solution to address this bug. Such that:
+When installing ggplot2, it may be required for some users to use the dependencies flag as a result of lazy loading affecting the install. This suggestion is not tied to any known bug discussion, and is advised based off instructor feedback/experience in resolving stochastic occurences of errors identified through delivery of this workshop:
 
 ```{r ch5-sol3, eval=FALSE}
 install.packages("ggplot2", dependencies = TRUE)


### PR DESCRIPTION
Dear maintainers,

This PR follows from a closed PR found at [#868 ](https://github.com/swcarpentry/r-novice-gapminder/pull/868). As per advice from the maintainer team, I have added the proposed update via an instructor note.

I am a SWC Instructor who regularly delivers this R workshop to researchers. Over the course of many workshops in 2023, there have been recurrent issues in relation to lazy loading, and dependency install failure when installing ggplot2 on some machines. 9/10 times, setting the dependencies flag to TRUE explicitly tends to resolve the issues encountered. The other 1/10 times are often new R users setting the library download location to a sync folder i.e. cloud storage (in my experience at least).

For your consideration, and best wishes.
