### PR TITLE
Replace size with linewidth

### DIFF
--- a/episodes/08-plot-ggplot2.Rmd
+++ b/episodes/08-plot-ggplot2.Rmd
@@ -270,18 +270,15 @@ ggplot(data = gapminder, mapping = aes(x = gdpPercap, y = lifeExp)) +
   geom_point(alpha = 0.5) + scale_x_log10() + geom_smooth(method="lm")
 ```
 
-We can make the line thicker by *setting* the **size** aesthetic in the
+We can make the line thicker by *setting* the **linewidth** aesthetic in the
 `geom_smooth` layer:
 
 ```{r lm-fit2, fig.alt="Scatter plot of life expectancy vs GDP per capita with a trend line summarising the relationship between variables. The blue trend line is slightly thicker than in the previous figure."}
 ggplot(data = gapminder, mapping = aes(x = gdpPercap, y = lifeExp)) +
-  geom_point(alpha = 0.5) + scale_x_log10() + geom_smooth(method="lm", size=1.5)
+  geom_point(alpha = 0.5) + scale_x_log10() + geom_smooth(method="lm", linewidth=1.5)
 ```
 
-There are two ways an *aesthetic* can be specified. Here we *set* the **size**
-aesthetic by passing it as an argument to `geom_smooth`. Previously in the
-lesson we've used the `aes` function to define a *mapping* between data
-variables and their visual representation.
+There are two ways an *aesthetic* can be specified. Here we *set* the **linewidth** aesthetic by passing it as an argument to `geom_smooth` and it is applied the same to the whole `geom`. Previously in the lesson we've used the `aes` function to define a *mapping* between data variables and their visual representation.
 
 :::::::::::::::::::::::::::::::::::::::  challenge
 
@@ -291,6 +288,8 @@ Modify the color and size of the points on the point layer in the previous
 example.
 
 Hint: do not use the `aes` function.
+
+Hint: the equivalent of `linewidth` for points is `size`.
 
 :::::::::::::::  solution
 
@@ -304,7 +303,7 @@ a specific variable.
 ```{r ch4a-sol, fig.alt="Scatter plot of life expectancy vs GDP per capita with a trend line summarising the relationship between variables. The plot illustrates the possibilities for styling visualisations in ggplot2 with data points enlarged, coloured orange, and displayed without transparency."}
 ggplot(data = gapminder, mapping = aes(x = gdpPercap, y = lifeExp)) +
  geom_point(size=3, color="orange") + scale_x_log10() +
- geom_smooth(method="lm", size=1.5)
+ geom_smooth(method="lm", linewidth=1.5)
 ```
 
 :::::::::::::::::::::::::
@@ -332,7 +331,7 @@ is placed inside the `aes()` call modifies a point's color based on its continen
 ```{r ch4b-sol}
 ggplot(data = gapminder, mapping = aes(x = gdpPercap, y = lifeExp, color = continent)) +
  geom_point(size=3, shape=17) + scale_x_log10() +
- geom_smooth(method="lm", size=1.5)
+ geom_smooth(method="lm", linewidth=1.5)
 ```
 
 :::::::::::::::::::::::::


### PR DESCRIPTION
Replace `size` with `linewidth` for `geom_smooth()` example. Using `size` for lines was deprecated per this error message:

```
> ggplot(data=gapminder,
+        mapping=aes(x=gdpPercap,
+                    y=lifeExp)) +
+   geom_point(alpha=0.5) +
+   scale_x_log10() +
+   geom_smooth(method='lm', size=1.5)
`geom_smooth()` using formula = 'y ~ x'
Warning message:
Using `size` aesthetic for lines was deprecated in ggplot2 3.4.0.
ℹ Please use `linewidth` instead.
This warning is displayed once every 8 hours.
Call `lifecycle::last_lifecycle_warnings()` to see where this warning was generated. 
```

Change throughout the lesson and additionally:
1. Adjust language in explanations to match
2. Add hint to challenge clarifying size is point equivalent of linewidth.
3. Add some additional explanation of difference between aesthetics with vs without mappings.

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._


_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
