### PR TITLE
Change "likes_string" to "likes_catnip"

### DIFF
--- a/episodes/04-data-structures-part1.Rmd
+++ b/episodes/04-data-structures-part1.Rmd
@@ -24,8 +24,8 @@ source: Rmd
 
 ```{r, include=FALSE}
 options(stringsAsFactors = FALSE)
-cats_orig <- data.frame(coat = c("calico", "black", "tabby"), weight = c(2.1, 5, 3.2), likes_string = c(1, 0, 1), stringsAsFactors = FALSE)
-cats_bad <- data.frame(coat = c("calico", "black", "tabby", "tabby"), weight = c(2.1, 5, 3.2, "2.3 or 2.4"), likes_string = c(1, 0, 1, 1), stringsAsFactors = FALSE)
+cats_orig <- data.frame(coat = c("calico", "black", "tabby"), weight = c(2.1, 5, 3.2), likes_catnip = c(1, 0, 1), stringsAsFactors = FALSE)
+cats_bad <- data.frame(coat = c("calico", "black", "tabby", "tabby"), weight = c(2.1, 5, 3.2, "2.3 or 2.4"), likes_catnip = c(1, 0, 1, 1), stringsAsFactors = FALSE)
 cats <- cats_orig
 ```
 
@@ -36,7 +36,7 @@ making a toy dataset in your `data/` directory, called `feline-data.csv`:
 ```{r}
 cats <- data.frame(coat = c("calico", "black", "tabby"),
                     weight = c(2.1, 5.0, 3.2),
-                    likes_string = c(1, 0, 1))
+                    likes_catnip = c(1, 0, 1))
 ```
 
 We can now save `cats` as a CSV file. It is good practice to call the argument
@@ -51,7 +51,7 @@ write.csv(x = cats, file = "data/feline-data.csv", row.names = FALSE)
 The contents of the new file, `feline-data.csv`:
 
 ```{r, eval=FALSE}
-coat,weight,likes_string
+coat,weight,likes_catnip
 calico,2.1,1
 black,5.0,0
 tabby,3.2,1
@@ -172,7 +172,7 @@ file.show("data/feline-data_v2.csv")
 ```
 
 ```{r, eval=FALSE}
-coat,weight,likes_string
+coat,weight,likes_catnip
 calico,2.1,1
 black,5.0,0
 tabby,3.2,1
@@ -221,7 +221,7 @@ while we investigate this behavior further:
 feline-data.csv:
 
 ```
-coat,weight,likes_string
+coat,weight,likes_catnip
 calico,2.1,1
 black,5.0,0
 tabby,3.2,1
@@ -362,16 +362,16 @@ may well be to blame; make sure everything is the same type in your vectors and
 your columns of data.frames, or you will get nasty surprises!
 
 But coercion can also be very useful! For example, in our `cats` data
-`likes_string` is numeric, but we know that the 1s and 0s actually represent
+`likes_catnip` is numeric, but we know that the 1s and 0s actually represent
 `TRUE` and `FALSE` (a common way of representing them). We should use the
 `logical` datatype here, which has two states: `TRUE` or `FALSE`, which is
 exactly what our data represents. We can 'coerce' this column to be `logical` by
 using the `as.logical` function:
 
 ```{r}
-cats$likes_string
-cats$likes_string <- as.logical(cats$likes_string)
-cats$likes_string
+cats$likes_catnip
+cats$likes_catnip <- as.logical(cats$likes_catnip)
+cats$likes_catnip
 ```
 
 :::::::::::::::::::::::::::::::::::::::  challenge


### PR DESCRIPTION
Closes #901 

Changed `likes_string` variable in the `cats` data frame to `likes_catnip` instead. This should clear up a frequent point of confusion where learners interpret "string" as referring to a character data type. See further discussion/description in #901.
