### PR TITLE
Update GH actions config file

### DIFF
--- a/.github/workflows/pr-receive.yaml
+++ b/.github/workflows/pr-receive.yaml
@@ -109,21 +109,21 @@ jobs:
       - name: "Upload PR"
         uses: actions/upload-artifact@v4
         with:
-          name: pr
+          name: pr-${{ github.run_id }}
           path: ${{ env.PR }}
           overwrite: true
 
       - name: "Upload Diff"
         uses: actions/upload-artifact@v4
         with:
-          name: diff
+          name: diff-${{ github.run_id }}
           path: ${{ env.CHIVE }}
           retention-days: 1
 
       - name: "Upload Build"
         uses: actions/upload-artifact@v4
         with:
-          name: built
+          name: built-${{ github.run_id }}
           path: ${{ env.MD }}
           retention-days: 1
 


### PR DESCRIPTION
One of our recent PRs failed with the GitHub action error.
https://github.com/swcarpentry/r-novice-gapminder/actions/runs/12642590727/job/35230110313

Think that can be addressed by modifying the workflow configuration to ensure that artifact names are unique.
I have appended a run id to artifact names. 