### PR TITLE
Fix typo in Data Structures Part 1

### DIFF
--- a/episodes/04-data-structures-part1.Rmd
+++ b/episodes/04-data-structures-part1.Rmd
@@ -74,7 +74,7 @@ cats <- read.csv(file = "data/feline-data.csv")
 cats
 ```
 
-The `read.table` function is used for reading in tabular data stored in a text
+The `read.csv` function is used for reading in tabular data stored in a text
 file where the columns of data are separated by punctuation characters such as
 CSV files (csv = comma-separated values). Tabs and commas are the most common
 punctuation characters used to separate or delimit data points in csv files.


### PR DESCRIPTION
The `read.csv` function was used in the code block, however it was incorrectly referred to as `read.table`. I have changed the reference from `read.table` to `read.csv` to reflect the correct name of the function used in the code.