### PR TITLE
Fix typo in data frame reference

### DIFF
--- a/episodes/04-data-structures-part1.Rmd
+++ b/episodes/04-data-structures-part1.Rmd
@@ -416,7 +416,7 @@ print(cats2)
 
 The data type of your data is as important as the data itself. Use a
 function we saw earlier to print out the data types of all columns of the
-`cats2` `data.frame`.
+`cats2` dataframe.
 
 :::::::::::::::  solution
 


### PR DESCRIPTION
Corrected a typo in one of the challenges that showed data frame as R code instead of the word
